### PR TITLE
ISO 19110 metadata schema configuration

### DIFF
--- a/geoportal/profiles/metadata/iso/iso19110/ReadMe.txt
+++ b/geoportal/profiles/metadata/iso/iso19110/ReadMe.txt
@@ -1,0 +1,36 @@
+/* See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * Esri Inc. licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+This customization supports the ability to create and publish/harvest ISO 19110 metadata to the Esri Geoportal Server. See http://github.com/Esri/geoportal-server/wiki/How-to-Publish-Resources for documentation for how to create, publish and harvest metadata to a geoportal, and http://github.com/Esri/geoportal-server/wiki/Add-a-Custom-Profile for details on Adding a Custom profile to the geoportal.
+
+To Apply:
+
+1) In the geoportal web application files, copy the iso-19110-fc-definition.xml and iso-19110-fc-template.xml files to the \\geoportal\WEB-INF\classes\gpt\metadata\iso directory
+
+2) Copy the iso19110 folder and all its contents to the \\geoportal\WEB-INF\classes\gpt\gxe\iso directory
+
+3) Add the following to the bottom of the \\geoportal\WEB-INF\classes\gpt\resources\gpt.properties file:
+
+# begin ISO19110 Feature Catalogue ============================================
+catalog.iso19110.isAbstract.true = True
+catalog.iso19110.isAbstract.false = False
+catalog.mdParam.schema.iso19110.featureCatalogue = ISO 19110 (Feature Catalogue)
+# end ISO19110 Feature Catalogue ============================================
+
+4) Add the following to the \\geoportal\WEB-INF\classes\gpt\metadata\schemas.xml file, anywhere before the final </schemas> tag:
+
+  <schema fileName="gpt/metadata/iso/iso-19110-fc-definition.xml"/>
+
+5) Save gpt.properties. Restart the geoportal web application for your changes to take effect. Now when you login as a publisher or administrator, and choose the option to create metadata using the geoportal's online form, you should see the ISO Feature Catalog entry in your list of supported geoportal schemas. Also, you should be able to upload or harvest ISO 19110 metadata.

--- a/geoportal/profiles/metadata/iso/iso19110/iso-19110-fc-definition.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso-19110-fc-definition.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ Esri Inc. licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<schema key="http://www.isotc211.org/2005/gfc" 
+        templateFile="gpt/metadata/iso/iso-19110-fc-template.xml"
+        cswOutputSchema="http://www.isotc211.org/2005/gfc" 
+        cswBriefXslt="" 
+        cswSummaryXslt="" 
+        xsdLocation="http://www.isotc211.org/2005/gfc/gfc.xsd">
+
+  
+  <!-- schema label -->
+  <label resourceKey="catalog.mdParam.schema.iso19110.featureCatalogue"/>
+
+  <!-- schema namespaces -->
+  <namespace prefix="gml" uri="http://www.opengis.net/gml/3.2" />
+  <namespace prefix="gmd" uri="http://www.isotc211.org/2005/gmd" />
+  <namespace prefix="gco" uri="http://www.isotc211.org/2005/gco" />
+  <namespace prefix="gfc" uri="http://www.isotc211.org/2005/gfc" />
+  <namespace prefix="gmx" uri="http://www.isotc211.org/2005/gmx" />
+  <namespace prefix="gsr" uri="http://www.isotc211.org/2005/gsr" />
+  <namespace prefix="gss" uri="http://www.isotc211.org/2005/gss" />
+  <namespace prefix="gts" uri="http://www.isotc211.org/2005/gts" />
+  
+  <!-- schema interrogation -->
+  <interrogation count="count(/gfc:FC_FeatureCatalogue)"/>
+  
+  <!-- indexables -->
+  <indexables fileName=""/>
+  
+  <!-- Geoportal XML editor -->
+  <editor fileName="gpt/gxe/iso/iso19110/iso19110-FeatureCatalog-editor.xml"/>
+  
+</schema>

--- a/geoportal/profiles/metadata/iso/iso19110/iso-19110-fc-template.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso-19110-fc-template.xml
@@ -1,0 +1,304 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<gfc:FC_FeatureCatalogue 
+	xmlns="http://www.isotc211.org/2005/gfc" 
+	xmlns:gco="http://www.isotc211.org/2005/gco" 
+	xmlns:gfc="http://www.isotc211.org/2005/gfc" 
+	xmlns:gmd="http://www.isotc211.org/2005/gmd" 
+	xmlns:gml="http://www.opengis.net/gml/3.2" 
+	xmlns:gmx="http://www.isotc211.org/2005/gmx" 
+	xmlns:gsr="http://www.isotc211.org/2005/gsr" 
+	xmlns:gss="http://www.isotc211.org/2005/gss"
+	xmlns:gts="http://www.isotc211.org/2005/gts" 
+	xmlns:xlink="http://www.w3.org/1999/xlink" 
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+	xsi:schemaLocation="http://www.isotc211.org/2005/gfc http://www.isotc211.org/2005/gfc/gfc.xsd" 
+	id="FC001" 
+	uuid="87ffdfd0-775a-11e0-a1f0-0800200c9a66">
+	<gmx:name>
+		<gco:CharacterString>Feature Catalogue for Provisional Processed CTD Data from the Deepwater Horizon Incident Response in the Gulf of Mexico May 08, 2010 through November 15 ,2010</gco:CharacterString>
+	</gmx:name>
+	<gmx:scope gco:nilReason="unknown"/>
+	<gmx:versionNumber gco:nilReason="unknown"/>
+	<gmx:versionDate gco:nilReason="unknown"/>
+	<gmx:language>
+		<gco:CharacterString>eng; US</gco:CharacterString>
+	</gmx:language>
+	<gmx:characterSet>
+		<gmd:MD_CharacterSetCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8" codeSpace="004"/>
+	</gmx:characterSet>
+	<gfc:producer xlink:arcrole="http://www.ngdc.noaa.gov/docucomp/component/7c7d17a0-4d66-11df-9879-0800200c9a66" xlink:title="DOC/NOAA/NESDIS/NODC/NCDDC&gt; National Coastal Data Development Center (pointOfContact)"/>
+	<gfc:featureType>
+		<gfc:FC_FeatureType>
+			<gfc:typeName>
+				<gco:LocalName>Header</gco:LocalName>
+			</gfc:typeName>
+			<gfc:definition>
+				<gco:CharacterString>CTD Header Information</gco:CharacterString>
+			</gfc:definition>
+			<gfc:isAbstract>
+				<gco:Boolean>false</gco:Boolean>
+			</gfc:isAbstract>
+			<gfc:featureCatalogue uuidref="87ffdfd0-775a-11e0-a1f0-0800200c9a66"/>
+			<gfc:carrierOfCharacteristics>
+				<gfc:FC_FeatureAttribute>
+					<gfc:memberName>
+						<gco:LocalName>Orig Datum Used</gco:LocalName>
+					</gfc:memberName>
+					<gfc:definition>
+						<gco:CharacterString>Original Datum Used</gco:CharacterString>
+					</gfc:definition>
+					<gfc:cardinality gco:nilReason="unknown"/>
+					<gfc:definitionReference>
+						<gfc:FC_DefinitionReference>
+							<gfc:definitionSource>
+								<gfc:FC_DefinitionSource>
+									<gfc:source>
+										<gmd:CI_Citation>
+											<gmd:title gco:nilReason="inapplicable"/>
+											<gmd:date gco:nilReason="unknown"/>
+											<gmd:citedResponsibleParty>
+												<gmd:CI_ResponsibleParty>
+													<gmd:organisationName>
+														<gco:CharacterString>Combined Data Management Sampling Data Format and Transmission Guidance</gco:CharacterString>
+													</gmd:organisationName>
+													<gmd:role>
+														<gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="resourceProvider" codeSpace="001"/>
+													</gmd:role>
+												</gmd:CI_ResponsibleParty>
+											</gmd:citedResponsibleParty>
+										</gmd:CI_Citation>
+									</gfc:source>
+								</gfc:FC_DefinitionSource>
+							</gfc:definitionSource>
+						</gfc:FC_DefinitionReference>
+					</gfc:definitionReference>
+				</gfc:FC_FeatureAttribute>
+			</gfc:carrierOfCharacteristics>
+			<gfc:carrierOfCharacteristics>
+				<gfc:FC_FeatureAttribute>
+					<gfc:memberName>
+						<gco:LocalName>Date</gco:LocalName>
+					</gfc:memberName>
+					<gfc:definition>
+						<gco:CharacterString>Date</gco:CharacterString>
+					</gfc:definition>
+					<gfc:cardinality gco:nilReason="unknown"/>
+					<gfc:definitionReference>
+						<gfc:FC_DefinitionReference>
+							<gfc:definitionSource>
+								<gfc:FC_DefinitionSource>
+									<gfc:source>
+										<gmd:CI_Citation>
+											<gmd:title gco:nilReason="inapplicable"/>
+											<gmd:date gco:nilReason="unknown"/>
+											<gmd:citedResponsibleParty>
+												<gmd:CI_ResponsibleParty>
+													<gmd:organisationName>
+														<gco:CharacterString>Combined Data Management Sampling Data Format and Transmission Guidance</gco:CharacterString>
+													</gmd:organisationName>
+													<gmd:role>
+														<gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="resourceProvider" codeSpace="001"/>
+													</gmd:role>
+												</gmd:CI_ResponsibleParty>
+											</gmd:citedResponsibleParty>
+										</gmd:CI_Citation>
+									</gfc:source>
+								</gfc:FC_DefinitionSource>
+							</gfc:definitionSource>
+						</gfc:FC_DefinitionReference>
+					</gfc:definitionReference>
+					<gfc:valueMeasurementUnit>
+						<gml:BaseUnit gml:id="dateUnit">
+							<gml:identifier codeSpace="MMDDYYYY"/>
+							<gml:unitsSystem nilReason="unknown"/>
+						</gml:BaseUnit>
+					</gfc:valueMeasurementUnit>
+				</gfc:FC_FeatureAttribute>
+			</gfc:carrierOfCharacteristics>
+			<gfc:carrierOfCharacteristics>
+				<gfc:FC_FeatureAttribute>
+					<gfc:memberName>
+						<gco:LocalName>Start Time</gco:LocalName>
+					</gfc:memberName>
+					<gfc:definition>
+						<gco:CharacterString>Start Time in GMT</gco:CharacterString>
+					</gfc:definition>
+					<gfc:cardinality gco:nilReason="unknown"/>
+					<gfc:definitionReference>
+						<gfc:FC_DefinitionReference>
+							<gfc:definitionSource>
+								<gfc:FC_DefinitionSource>
+									<gfc:source>
+										<gmd:CI_Citation>
+											<gmd:title gco:nilReason="inapplicable"/>
+											<gmd:date gco:nilReason="unknown"/>
+											<gmd:citedResponsibleParty>
+												<gmd:CI_ResponsibleParty>
+													<gmd:organisationName>
+														<gco:CharacterString>Combined Data Management Sampling Data Format and Transmission Guidance</gco:CharacterString>
+													</gmd:organisationName>
+													<gmd:role>
+														<gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="resourceProvider" codeSpace="001"/>
+													</gmd:role>
+												</gmd:CI_ResponsibleParty>
+											</gmd:citedResponsibleParty>
+										</gmd:CI_Citation>
+									</gfc:source>
+								</gfc:FC_DefinitionSource>
+							</gfc:definitionSource>
+						</gfc:FC_DefinitionReference>
+					</gfc:definitionReference>
+					<gfc:valueMeasurementUnit>
+						<gml:BaseUnit gml:id="startTimeUnit">
+							<gml:identifier codeSpace="HHMMSS"/>
+							<gml:unitsSystem nilReason="unknown"/>
+						</gml:BaseUnit>
+					</gfc:valueMeasurementUnit>
+				</gfc:FC_FeatureAttribute>
+			</gfc:carrierOfCharacteristics>
+		</gfc:FC_FeatureType>
+	</gfc:featureType>
+	<gfc:featureType>
+		<gfc:FC_FeatureType>
+			<gfc:typeName>
+				<gco:LocalName>CTD Detail Record</gco:LocalName>
+			</gfc:typeName>
+			<gfc:definition>
+				<gco:CharacterString>CTD Measurements</gco:CharacterString>
+			</gfc:definition>
+			<gfc:isAbstract>
+				<gco:Boolean>false</gco:Boolean>
+			</gfc:isAbstract>
+			<gfc:featureCatalogue uuidref="FC001"/>
+			<gfc:carrierOfCharacteristics>
+				<gfc:FC_FeatureAttribute>
+					<gfc:memberName>
+						<gco:LocalName>Long</gco:LocalName>
+					</gfc:memberName>
+					<gfc:definition>
+						<gco:CharacterString>Longitude</gco:CharacterString>
+					</gfc:definition>
+					<gfc:cardinality gco:nilReason="unknown"/>
+					<gfc:definitionReference>
+						<gfc:FC_DefinitionReference>
+							<gfc:definitionSource>
+								<gfc:FC_DefinitionSource>
+									<gfc:source>
+										<gmd:CI_Citation>
+											<gmd:title gco:nilReason="inapplicable"/>
+											<gmd:date gco:nilReason="unknown"/>
+											<gmd:citedResponsibleParty>
+												<gmd:CI_ResponsibleParty>
+													<gmd:organisationName>
+														<gco:CharacterString>Shipboard Sampling Data Format and Transmission Specification
+</gco:CharacterString>
+													</gmd:organisationName>
+													<gmd:role>
+														<gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml
+#CI_RoleCode" codeListValue="resourceProvider" codeSpace="001"/>
+													</gmd:role>
+												</gmd:CI_ResponsibleParty>
+											</gmd:citedResponsibleParty>
+										</gmd:CI_Citation>
+									</gfc:source>
+								</gfc:FC_DefinitionSource>
+							</gfc:definitionSource>
+						</gfc:FC_DefinitionReference>
+					</gfc:definitionReference>
+					<gfc:valueMeasurementUnit>
+						<gml:BaseUnit gml:id="longUnit2">
+							<gml:identifier codeSpace="decimal degrees to 8 decimal places"/>
+							<gml:unitsSystem nilReason="unknown"/>
+						</gml:BaseUnit>
+					</gfc:valueMeasurementUnit>
+				</gfc:FC_FeatureAttribute>
+			</gfc:carrierOfCharacteristics>
+			<gfc:carrierOfCharacteristics>
+				<gfc:FC_FeatureAttribute>
+					<gfc:memberName>
+						<gco:LocalName>Lat</gco:LocalName>
+					</gfc:memberName>
+					<gfc:definition>
+						<gco:CharacterString>Latitude</gco:CharacterString>
+					</gfc:definition>
+					<gfc:cardinality gco:nilReason="unknown"/>
+					<gfc:definitionReference>
+						<gfc:FC_DefinitionReference>
+							<gfc:definitionSource>
+								<gfc:FC_DefinitionSource>
+									<gfc:source>
+										<gmd:CI_Citation>
+											<gmd:title gco:nilReason="inapplicable"/>
+											<gmd:date gco:nilReason="unknown"/>
+											<gmd:citedResponsibleParty>
+												<gmd:CI_ResponsibleParty>
+													<gmd:organisationName>
+														<gco:CharacterString>Data Management Sampling Format and Transmission Guidance
+</gco:CharacterString>
+													</gmd:organisationName>
+													<gmd:role>
+														<gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml
+#CI_RoleCode" codeListValue="resourceProvider" codeSpace="001"/>
+													</gmd:role>
+												</gmd:CI_ResponsibleParty>
+											</gmd:citedResponsibleParty>
+										</gmd:CI_Citation>
+									</gfc:source>
+								</gfc:FC_DefinitionSource>
+							</gfc:definitionSource>
+						</gfc:FC_DefinitionReference>
+					</gfc:definitionReference>
+					<gfc:valueMeasurementUnit>
+						<gml:BaseUnit gml:id="latUnit2">
+							<gml:identifier codeSpace="Decimal Degrees to 8 decimal places"/>
+							<gml:unitsSystem nilReason="unknown"/>
+						</gml:BaseUnit>
+					</gfc:valueMeasurementUnit>
+				</gfc:FC_FeatureAttribute>
+			</gfc:carrierOfCharacteristics>
+			<gfc:carrierOfCharacteristics>
+				<gfc:FC_FeatureAttribute>
+					<gfc:memberName>
+						<gco:LocalName>Depth_m</gco:LocalName>
+					</gfc:memberName>
+					<gfc:definition>
+						<gco:CharacterString>Depth</gco:CharacterString>
+					</gfc:definition>
+					<gfc:cardinality gco:nilReason="unknown"/>
+					<gfc:definitionReference>
+						<gfc:FC_DefinitionReference>
+							<gfc:definitionSource>
+								<gfc:FC_DefinitionSource>
+									<gfc:source>
+										<gmd:CI_Citation>
+											<gmd:title gco:nilReason="inapplicable"/>
+											<gmd:date gco:nilReason="unknown"/>
+											<gmd:citedResponsibleParty>
+												<gmd:CI_ResponsibleParty>
+													<gmd:organisationName>
+														<gco:CharacterString>Combined Data Management Sampling Data Format and Transmission Guidance
+</gco:CharacterString>
+													</gmd:organisationName>
+													<gmd:role>
+														<gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml
+#CI_RoleCode" codeListValue="resourceProvider" codeSpace="001"/>
+													</gmd:role>
+												</gmd:CI_ResponsibleParty>
+											</gmd:citedResponsibleParty>
+										</gmd:CI_Citation>
+									</gfc:source>
+								</gfc:FC_DefinitionSource>
+							</gfc:definitionSource>
+						</gfc:FC_DefinitionReference>
+					</gfc:definitionReference>
+					<gfc:valueMeasurementUnit>
+						<gml:BaseUnit gml:id="depthUnit">
+							<gml:identifier codeSpace="meters"/>
+							<gml:unitsSystem nilReason="unknown"/>
+						</gml:BaseUnit>
+					</gfc:valueMeasurementUnit>
+				</gfc:FC_FeatureAttribute>
+			</gfc:carrierOfCharacteristics>
+		</gfc:FC_FeatureType>
+	</gfc:featureType>
+</gfc:FC_FeatureCatalogue>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/FC_FeatureCatalogue.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/FC_FeatureCatalogue.xml
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+	xmlns:h="http://www.esri.com/geoportal/gxe/html" 
+	g:targetName="gfc:FC_FeatureCatalogue" 
+	g:minOccurs="1" g:maxOccurs="1" 
+	g:i18nBase="catalog.gxe.iso19110" 
+	g:label="$i18nBase" 
+	g:extends="$base/core/xml/Element.xml">
+	<g:namespaces g:extensible="true">
+		<g:namespace g:prefix="ows" g:uri="http://www.opengis.net/ows"/>
+		<g:namespace g:prefix="gmd" g:uri="http://www.isotc211.org/2005/gmd" /> 
+		<g:namespace g:prefix="gco" g:uri="http://www.isotc211.org/2005/gco" />
+		<g:namespace g:prefix="gfc" g:uri="http://www.isotc211.org/2005/gfc"/>
+		<g:namespace g:prefix="gmx" g:uri="http://www.isotc211.org/2005/gmx" />
+		<g:namespace g:prefix="gsr" g:uri="http://www.isotc211.org/2005/gsr" />
+		<g:namespace g:prefix="gss" g:uri="http://www.isotc211.org/2005/gss" />
+		<g:namespace g:prefix="gts" g:uri="http://www.isotc211.org/2005/gts" />
+		<g:namespace g:prefix="xlink" g:uri="http://www.w3.org/1999/xlink" />
+		<g:namespace g:prefix="xsi" g:uri="http://www.w3.org/2001/XMLSchema-instance" />
+	</g:namespaces>
+	<g:body>
+		<g:attribute g:targetName="uuid" g:value="#{EditMetadataController.newUuid}">
+			<g:body>
+				<!-- <g:input g:extends="$base/core/ui/InputText.xml" h:readonly="readonly"/> -->
+			</g:body>
+		</g:attribute>
+		<g:element g:targetName="gmx:name" g:minOccurs="1" g:maxOccurs="1" g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+		<g:element g:targetName="gmx:scope" g:minOccurs="1" g:maxOccurs="unbounded" g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml">
+			<g:body>
+				<g:attribute g:extends="$base/schema/gco/gcoBase/nilReason.xml"/>
+			</g:body>
+		</g:element>
+		<g:element g:targetName="gmx:versionNumber" g:minOccurs="1" g:maxOccurs="1" g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+		<g:element g:targetName="gmx:versionDate" g:minOccurs="1" g:maxOccurs="1" g:extends="$base/schema/gco/basicTypes/Date_PropertyType.xml"/>
+		<g:element g:targetName="gmx:language" g:minOccurs="0" g:maxOccurs="1" g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+		<g:element g:targetName="gmx:characterSet" g:minOccurs="0" g:maxOccurs="1" g:extends="$base/schema/gmd/identification/MD_CharacterSetCode_PropertyType.xml"/>
+		<g:element xmlns:g="http://www.esri.com/geoportal/gxe" xmlns:h="http://www.esri.com/geoportal/gxe/html" g:targetName="gfc:producer" g:minOccurs="1" g:maxOccurs="1" g:extends="$base/xtn/ui/UI_Element.xml">
+			<g:body>
+				<g:element g:targetName="gmd:CI_ResponsibleParty" g:minOccurs="1" g:maxOccurs="1" g:i18nBase="catalog.iso19139.CI_ResponsibleParty" h:tag="div" g:jsClass="gxe.control.Element">
+					<g:element g:targetName="gmd:organisationName" g:minOccurs="1" g:maxOccurs="1" g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+					<g:element g:targetName="gmd:contactInfo" g:minOccurs="0" g:maxOccurs="1" h:tag="div" g:jsClass="gxe.control.Element">
+						<g:element g:targetName="gmd:CI_Contact" g:minOccurs="0" g:maxOccurs="1" h:tag="div" g:jsClass="gxe.control.Element">
+							<g:element g:targetName="gmd:address" g:minOccurs="0" g:maxOccurs="1" h:tag="div" g:jsClass="gxe.control.Element">
+								<g:element g:targetName="gmd:CI_Address" g:minOccurs="0" g:maxOccurs="1" h:tag="div" g:jsClass="gxe.control.Element">
+									<g:element g:targetName="gmd:electronicMailAddress" g:minOccurs="0" g:maxOccurs="unbounded" g:label="$i18n.catalog.iso19139.CI_Address.electronicMailAddress" g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml">
+										<g:body>
+											<g:element g:value="#{EditMetadataController.userProfile['email'].value}"/>
+										</g:body>
+									</g:element>
+								</g:element>
+							</g:element>
+						</g:element>
+					</g:element>
+					<g:element g:targetName="gmd:role" g:minOccurs="1" g:maxOccurs="1" g:extends="$base/schema/gmd/citation/CI_RoleCode_PropertyType.xml"/>
+				</g:element>
+			</g:body>
+		</g:element>
+		<g:element g:targetName="gfc:featureType" g:minOccurs="1" g:maxOccurs="unbounded" g:extends="$base/xtn/ui/UI_Element.xml">
+			<g:body>
+				<g:element g:targetName="gfc:FC_FeatureType" g:minOccurs="1" g:maxOccurs="1" h:tag="div" g:jsClass="gxe.control.Element">
+					<g:element g:targetName="gfc:typeName" g:minOccurs="1" g:maxOccurs="1" g:extends="$base/schema/gco/basicTypes/LocalName_PropertyType.xml"/>
+					<g:element g:targetName="gfc:definition" g:minOccurs="1" g:maxOccurs="1" g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+					<g:element g:targetName="gfc:isAbstract" g:minOccurs="1" g:maxOccurs="1" g:extends="$base/xtn/ui/UI_Element.xml">
+						<g:body>
+							<g:element g:targetName="gco:Boolean" g:extends="$base/core/ui/InputSelectOne.xml">
+								<g:options>
+									<g:option g:label="" g:value=""/>
+									<g:option g:label="$i18n.catalog.iso19110.isAbstract.true" g:value="true"/>
+									<g:option g:label="$i18n.catalog.iso19110.isAbstract.false" g:value="false"/>
+								</g:options>
+							</g:element>
+						</g:body>
+					</g:element>
+
+					<g:element g:targetName="gfc:featureCatalogue" g:minOccurs="1" g:maxOccurs="1" g:preferOpen="true" g:extends="$base/xtn/ui/UI_Element.xml">
+						<g:body>
+							<g:attribute g:targetName="uuidref" g:value="FC001" />
+						</g:body>
+					</g:element>
+					
+					<g:element g:targetName="gfc:carrierOfCharacteristics" g:minOccurs="0" g:maxOccurs="unbounded" g:extends="$base/xtn/ui/UI_Element.xml">
+						<g:body>
+							<g:element g:targetName="gfc:FC_FeatureAttribute" g:extends="$base/xtn/ui/UI_Element.xml">
+								<g:body>
+									<g:element g:targetName="gfc:memberName" g:minOccurs="1" g:maxOccurs="1" g:extends="$base/schema/gco/basicTypes/LocalName_PropertyType.xml"/>
+									<g:element g:targetName="gfc:definition" g:minOccurs="1" g:maxOccurs="1" g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+									<g:element g:targetName="gfc:cardinality" g:minOccurs="1" g:maxOccurs="1" g:extends="$base/schema/gco/basicTypes/Multiplicity_PropertyType.xml"/>
+									<g:element g:targetName="gfc:definitionReference" g:extends="$base/xtn/ui/UI_Element.xml">
+										<g:body>
+											<g:element g:targetName="gfc:FC_DefinitionReference" g:extends="$base/xtn/ui/UI_Element.xml">
+												<g:body>
+													<g:element g:targetName="gfc:definitionSource" g:extends="$base/xtn/ui/UI_Element.xml">
+														<g:body>
+															<g:element g:targetName="gfc:FC_DefinitionSource" g:extends="$base/xtn/ui/UI_Element.xml">
+																<g:body>
+																	<g:element g:targetName="gfc:source" g:extends="$base/xtn/ui/UI_Element.xml">
+																		<g:body>
+																			<g:element g:targetName="gmd:CI_Citation" g:minOccurs="0" g:maxOccurs="1" g:extends="$base/schema/gmd/citation/CI_Citation_Type.xml" >
+																			</g:element>
+																			<g:body>
+																				<g:element g:targetName="gmd:spatialRepresentationType" g:minOccurs="0" g:maxOccurs="unbounded" g:extends="$base/schema/gmd/identification/MD_SpatialRepresentationTypeCode_PropertyType.xml"/>
+																				<g:element g:targetName="gmd:spatialResolution" g:minOccurs="0" g:maxOccurs="unbounded" g:extends="$base/schema/gmd/identification/MD_Resolution_PropertyType.xml"/>
+																				<g:tabs g:extends="$base/xtn/ui/UI_Tabs.xml" g:label="$i18n.catalog.gxe.general.more">
+																					<g:body>
+																						<g:element g:targetName="gmd:language" g:minOccurs="1" g:maxOccurs="unbounded" g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+																						<g:element g:targetName="gmd:characterSet" g:minOccurs="0" g:maxOccurs="unbounded" g:extends="$base/schema/gmd/identification/MD_CharacterSetCode_PropertyType.xml"/>
+																						<g:element g:targetName="gmd:topicCategory" g:minOccurs="0" g:maxOccurs="unbounded" g:extends="$base/schema/gmd/identification/MD_TopicCategoryCode_PropertyType.xml"/>
+																						<g:element g:targetName="gmd:environmentDescription" g:minOccurs="0" g:maxOccurs="1" g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+																						<g:element g:targetName="gmd:extent" g:minOccurs="0" g:maxOccurs="unbounded" g:extends="$base/schema/gmd/extent/EX_Extent_PropertyType.xml"/>
+																						<g:element g:targetName="gmd:supplementalInformation" g:minOccurs="0" g:maxOccurs="1" g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+																					</g:body>
+																				</g:tabs>
+																			</g:body>
+																		</g:body>
+																	</g:element>
+																</g:body>
+															</g:element>
+														</g:body>
+													</g:element>
+												</g:body>
+											</g:element>
+										</g:body>
+									</g:element>
+								</g:body>
+							</g:element>
+						</g:body>
+					</g:element>
+				</g:element>
+			</g:body>
+		</g:element>
+	</g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/iso19110-FeatureCatalog-editor.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/iso19110-FeatureCatalog-editor.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Editor ISO 19110 (FeatureCatalog) -->        
+<g:editor xmlns:g="http://www.esri.com/geoportal/gxe"
+          xmlns:h="http://www.esri.com/geoportal/gxe/html"
+          g:extends="gpt/gxe/editor.xml">    
+          
+  <g:rootElement g:overridable="true" g:extends="$base/FC_FeatureCatalogue.xml"/>
+  
+</g:editor>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/AbstractGenericName.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/AbstractGenericName.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gco:AbstractGenericName"
+           g:extends="$base/xtn/ui/UI_Wrapped_Element.xml">
+  <g:body>
+  
+    <!--  the xsd references gml:CodeType which has a codeSpace attribute -->
+    <g:attribute g:targetNS="" g:targetName="codeSpace"
+      g:use="optional" g:valueType="xs:anyURI"
+      g:label="$i18n.catalog.iso19139.gco.CodeListValue.codeSpace" 
+      g:extends="$base/core/xml/Attribute.xml"/>  
+      
+    <g:textNode g:extends="$base/core/xml/TextNode.xml"/>
+    
+  </g:body>     
+</g:element> 

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/Angle.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/Angle.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gco:Angle"
+           g:extends="$base/schema/gco/basicTypes/Measure.xml"/> 
+

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/Angle_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/Angle_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/xtn/Wrapped_BasicPropertyType.xml">
+  <g:body>
+    <g:element g:minOccurs="$parent" g:extends="$base/schema/gco/basicTypes/Angle.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/Binary.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/Binary.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gco:Binary" 
+           g:extends="$base/schema/gco/basicTypes/Binary_Type.xml"/> 

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/Binary_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/Binary_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/xtn/Wrapped_BasicPropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gco/basicTypes/Binary.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/Binary_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/Binary_Type.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/xtn/ui/UI_Wrapped_Element.xml"> 
+  <g:body>
+    <g:attribute g:targetNS="" g:targetName="src" g:valueType="xs:anyURI"
+       g:extends="$base/core/xml/Attribute.xml"/>
+    <!-- <g:textNode g:extends="$base/core/xml/TextNode.xml"/> -->
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/Boolean.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/Boolean.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gco:Boolean" g:valueType="xs:boolean"
+           g:extends="$base/xtn/ui/UI_Wrapped_ElementTextOnly.xml"/> 
+

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/Boolean_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/Boolean_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/xtn/Wrapped_BasicPropertyType.xml">
+  <g:body>
+    <g:element g:minOccurs="$parent" g:extends="$base/schema/gco/basicTypes/Boolean.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/CharacterString.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/CharacterString.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gco:CharacterString"
+           g:extends="$base/xtn/ui/UI_Wrapped_ElementTextOnly.xml"/> 

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/CharacterString_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/CharacterString_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/xtn/Wrapped_BasicPropertyType.xml">
+  <g:body>
+    <g:element g:minOccurs="$parent" g:extends="$base/schema/gco/basicTypes/CharacterString.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/Date.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/Date.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gco:Date" g:valueType="xs:date"
+           g:nillable="true" 
+           g:extends="$base/schema/gco/basicTypes/Date_Type.xml"/> 
+

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/DateTime.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/DateTime.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gco:DateTime" g:valueType="xs:dateTime"
+           g:extends="$base/xtn/ui/UI_Wrapped_ElementTextOnly.xml"/> 

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/DateTime_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/DateTime_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/xtn/Wrapped_BasicPropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gco/basicTypes/DateTime.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/Date_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/Date_PropertyType.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/xtn/Wrapped_BasicPropertyType.xml">       
+  <g:body>
+  
+    <!-- MODIFIED - the container below mirrors the original XSD structure -->
+    <g:container g:rendered="$editor.isOriginalMode">
+    
+	    <g:elementChoice g:minOccurs="0" g:extends="$base/xtn/ui/UI_ElementChoice.xml">
+	      <g:body>
+	        <g:element g:extensible="false" g:extends="$base/schema/gco/basicTypes/Date.xml"/>
+	        <g:element g:extensible="false" g:extends="$base/schema/gco/basicTypes/DateTime.xml"/>
+	      </g:body>
+	    </g:elementChoice>
+	    
+	  </g:container>
+	  
+	  <!-- MODIFIED - the container below produces a simplified structure -->
+    <g:container g:rendered="$editor.isSimplifiedMode">
+      <!--  TODO need to implement a g:alternateTargetName grab values from gco:DateTime -->
+      <g:element g:minOccurs="$parent" g:extends="$base/schema/gco/basicTypes/Date.xml"/>
+    </g:container>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/Date_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/Date_Type.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/xtn/ui/UI_Wrapped_ElementTextOnly.xml"> 
+  <!-- <xs:union memberTypes="xs:date xs:gYearMonth xs:gYear"/> -->
+  <g:body>
+    <g:input h:size="30" g:tip="$i18n.catalog.general.inputDateFormat"
+      g:extends="$base/core/ui/InputText.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/Decimal.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/Decimal.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gco:Decimal" g:valueType="xs:decimal"
+           g:extends="$base/xtn/ui/UI_Wrapped_ElementTextOnly.xml"/> 
+

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/Decimal_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/Decimal_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/xtn/Wrapped_BasicPropertyType.xml">
+  <g:body>
+    <g:element g:minOccurs="$parent" g:extends="$base/schema/gco/basicTypes/Decimal.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/Distance.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/Distance.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gco:Distance"
+           g:extends="$base/schema/gco/basicTypes/Length.xml"/> 
+

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/Distance_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/Distance_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/xtn/Wrapped_BasicPropertyType.xml">
+  <g:body>
+    <g:element g:minOccurs="$parent" g:extends="$base/schema/gco/basicTypes/Distance.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/GenericName_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/GenericName_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/xtn/Wrapped_BasicPropertyType.xml">
+  <g:body>
+    <g:element g:minOccurs="$parent" g:extends="$base/schema/gco/basicTypes/AbstractGenericName.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/Integer.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/Integer.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gco:Integer" g:valueType="xs:integer"
+           g:extends="$base/xtn/ui/UI_Wrapped_ElementTextOnly.xml"/> 
+

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/Integer_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/Integer_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/xtn/Wrapped_BasicPropertyType.xml">
+  <g:body>
+    <g:element g:minOccurs="$parent" g:extends="$base/schema/gco/basicTypes/Integer.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/Length.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/Length.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gco:Length" g:i18nBase="catalog.iso19139.Length"
+           g:extends="$base/schema/gco/basicTypes/Measure.xml"> 
+  <g:body>
+    <g:attribute g:extends="$base/xtn/ui/UI_Attribute.xml" g:targetNS="" g:targetName="uom" g:use="required">
+      <g:body>
+        <g:input g:extends="$base/core/ui/InputSelectOne.xml">
+          <g:options>
+            <g:option g:label="" g:value="" />
+            <g:option g:label="$i18nBase.km" g:value="km" />
+            <g:option g:label="$i18nBase.m" g:value="m"/>
+            <g:option g:label="$i18nBase.mi" g:value="mi"/>
+            <g:option g:label="$i18nBase.ft" g:value="ft"/>
+          </g:options>
+        </g:input>
+      </g:body>          
+    </g:attribute>     
+  </g:body>
+</g:element>
+

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/Length_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/Length_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/xtn/Wrapped_BasicPropertyType.xml">
+  <g:body>
+    <g:element g:minOccurs="$parent" g:extends="$base/schema/gco/basicTypes/Length.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/LocalName.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/LocalName.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gco:LocalName"
+           g:extends="$base/schema/gco/basicTypes/AbstractGenericName.xml"/> 

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/LocalName_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/LocalName_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/xtn/Wrapped_BasicPropertyType.xml">
+  <g:body>
+    <g:element g:minOccurs="$parent" g:extends="$base/schema/gco/basicTypes/LocalName.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/Measure.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/Measure.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gco:Measure" g:valueType="xs:double"
+           g:extends="$base/xtn/ui/UI_Wrapped_ElementTextOnly.xml"> 
+           
+           
+<!-- 
+
+  TODO
+
+  /gml/basicTypes.xsd
+  
+  <complexType name="MeasureType">
+    <annotation>
+      <documentation>gml:MeasureType supports recording an amount encoded as a value of XML Schema double, together with a units of measure indicated by an attribute uom, short for â€œunits Of measureâ€. The value of the uom attribute identifies a reference system for the amount, usually a ratio or interval scale.</documentation>
+    </annotation>
+    <simpleContent>
+      <extension base="double">
+        <attribute name="uom" type="gml:UomIdentifier" use="required"/>
+      </extension>
+    </simpleContent>
+  </complexType>
+  <simpleType name="UomIdentifier">
+    <annotation>
+      <documentation>The simple type gml:UomIdentifer defines the syntax and value space of the unit of measure identifier.</documentation>
+    </annotation>
+    <union memberTypes="gml:UomSymbol gml:UomURI"/>
+  </simpleType>
+  <simpleType name="UomSymbol">
+    <annotation>
+      <documentation>This type specifies a character string of length at least one, and restricted such that it must not contain any of the following characters: â€œ:â€ (colon), â€œ â€œ (space), (newline), (carriage return), (tab). This allows values corresponding to familiar abbreviations, such as â€œkgâ€, â€œm/sâ€, etc. 
+It is recommended that the symbol be an identifier for a unit of measure as specified in the â€œUnified Code of Units of Measure" (UCUM) (http://aurora.regenstrief.org/UCUM). This provides a set of symbols and a grammar for constructing identifiers for units of measure that are unique, and may be easily entered with a keyboard supporting the limited character set known as 7-bit ASCII. ISO 2955 formerly provided a specification with this scope, but was withdrawn in 2001. UCUM largely follows ISO 2955 with modifications to remove ambiguities and other problems.</documentation>
+    </annotation>
+    <restriction base="string">
+      <pattern value="[^: \n\r\t]+"/>
+    </restriction>
+  </simpleType>
+  <simpleType name="UomURI">
+    <annotation>
+      <documentation>This type specifies a URI, restricted such that it must start with one of the following sequences: â€œ#â€, â€œ./â€, â€œ../â€, or a string of characters followed by a â€œ:â€. These patterns ensure that the most common URI forms are supported, including absolute and relative URIs and URIs that are simple fragment identifiers, but prohibits certain forms of relative URI that could be mistaken for unit of measure symbol . 
+NOTE  It is possible to re-write such a relative URI to conform to the restriction (e.g. â€œ./m/sâ€).
+In an instance document, on elements of type gml:MeasureType the mandatory uom attribute shall carry a value corresponding to either 
+- a conventional unit of measure symbol,
+- a link to a definition of a unit of measure that does not have a conventional symbol, or when it is desired to indicate a precise or variant definition.</documentation>
+    </annotation>
+    <restriction base="anyURI">
+      <pattern value="([a-zA-Z][a-zA-Z0-9\-\+\.]*:|\.\./|\./|#).*"/>
+    </restriction>
+  </simpleType>
+
+ -->
+ 
+ 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/Measure_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/Measure_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/xtn/Wrapped_BasicPropertyType.xml">
+  <g:body>
+    <g:element g:minOccurs="$parent" g:extends="$base/schema/gco/basicTypes/Measure.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/MemberName.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/MemberName.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gco:MemberName" 
+           g:extends="$base/schema/gco/basicTypes/MemberName_Type.xml"/> 
+

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/MemberName_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/MemberName_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="$parent" g:extends="$base/schema/gco/basicTypes/MemberName.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/MemberName_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/MemberName_Type.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.MemberName" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/AbstractObject_Type.xml">
+  <g:annotation>
+    <g:documentation>A MemberName is a LocalName that references either an attribute slot in a record or  recordType or an attribute, operation, or association role in an object instance or  type description in some form of schema. The stored value "aName" is the returned value for the "aName()" operation.</g:documentation>
+  </g:annotation>
+  <g:body>
+  
+    <g:element g:targetName="gco:aName" g:minOccurs="1" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+      
+    <g:element g:targetName="gco:attributeType" g:minOccurs="1" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/TypeName_PropertyType.xml"/>
+    
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/Multiplicity.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/Multiplicity.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gco:Multiplicity" 
+           g:extends="$base/schema/gco/basicTypes/Multiplicity_Type.xml"/> 

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/MultiplicityRange.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/MultiplicityRange.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gco:MultiplicityRange" 
+           g:extends="$base/schema/gco/basicTypes/MultiplicityRange_Type.xml"/> 

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/MultiplicityRange_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/MultiplicityRange_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="$parent" g:extends="$base/schema/gco/basicTypes/MultiplicityRange.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/MultiplicityRange_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/MultiplicityRange_Type.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.MultiplicityRange" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/AbstractObject_Type.xml">
+  <g:annotation>
+    <g:documentation>A component of a multiplicity, consisting of an non-negative lower bound, and a potentially infinite upper bound.</g:documentation>
+  </g:annotation>
+  <g:body>
+  
+    <g:element g:targetName="gco:lower" g:minOccurs="1" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/Integer_PropertyType.xml"/>
+    
+    <g:element g:targetName="gco:upper" g:minOccurs="1" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/UnlimitedInteger_PropertyType.xml"/>
+    
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/Multiplicity_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/Multiplicity_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="$parent" g:extends="$base/schema/gco/basicTypes/Multiplicity.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/Multiplicity_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/Multiplicity_Type.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.Multiplicity" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/AbstractObject_Type.xml">
+  <g:annotation>
+    <g:documentation>Use to represent the possible cardinality of a relation. Represented by a set of simple multiplicity ranges.</g:documentation>
+  </g:annotation>
+  <g:body>
+  
+    <g:element g:targetName="gco:range" g:minOccurs="1" g:maxOccurs="unbounded"
+      g:extends="$base/schema/gco/basicTypes/MultiplicityRange_PropertyType.xml"/>
+    
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/Number_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/Number_PropertyType.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/core/xml/Element.xml">       
+  <g:body>
+    <g:attribute g:extends="$base/schema/gco/gcoBase/nilReason.xml"/>
+    <g:elementChoice g:minOccurs="0" g:extends="$base/core/xml/ElementChoice.xml">
+      <g:body>
+        <g:element g:extends="$base/schema/gco/basicTypes/Real.xml"/>
+        <g:element g:extends="$base/schema/gco/basicTypes/Decimal.xml"/>
+        <g:element g:extends="$base/schema/gco/basicTypes/Integer.xml"/>
+      </g:body>
+    </g:elementChoice>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/Real.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/Real.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gco:Real" g:valueType="xs:double"
+           g:extends="$base/xtn/ui/UI_Wrapped_ElementTextOnly.xml"/> 
+

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/Real_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/Real_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/xtn/Wrapped_BasicPropertyType.xml">
+  <g:body>
+    <g:element g:minOccurs="$parent" g:extends="$base/schema/gco/basicTypes/Real.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/Record.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/Record.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gco:Record" 
+           g:extends="$base/xtn/ui/UI_Wrapped_ElementTextOnly.xml"/> 

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/RecordType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/RecordType.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gco:RecordType" 
+           g:extends="$base/schema/gco/basicTypes/RecordType_Type.xml"/> 

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/RecordType_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/RecordType_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/xtn/Wrapped_BasicPropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gco/basicTypes/RecordType.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/RecordType_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/RecordType_Type.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:valueType="xs:string" g:extends="$base/core/xml/Element.xml"> 
+  <g:body>
+    <!-- <xs:attributeGroup ref="xlink:simpleLink"/> -->
+    <g:textNode g:extends="$base/core/xml/TextNode.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/Record_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/Record_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gco/basicTypes/Record.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/Scale.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/Scale.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gco:Scale"
+           g:extends="$base/schema/gco/basicTypes/Measure.xml"/> 
+

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/Scale_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/Scale_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/xtn/Wrapped_BasicPropertyType.xml">
+  <g:body>
+    <g:element g:minOccurs="$parent" g:extends="$base/schema/gco/basicTypes/Scale.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/ScopedName.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/ScopedName.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gco:ScopedName"
+           g:extends="$base/schema/gco/basicTypes/AbstractGenericName.xml"/> 

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/ScopedName_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/ScopedName_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/xtn/Wrapped_BasicPropertyType.xml">
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gco/basicTypes/ScopedName.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/TypeName.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/TypeName.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gco:TypeName" 
+           g:extends="$base/schema/gco/basicTypes/TypeName_Type.xml"/> 
+

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/TypeName_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/TypeName_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gco/basicTypes/TypeName.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/TypeName_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/TypeName_Type.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.TypeName" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/AbstractObject_Type.xml">
+  <g:annotation>
+    <g:documentation>A TypeName is a LocalName that references either a recordType or object type in some form of schema. The stored value "aName" is the returned value for the "aName()" operation. This is the types name.  - For parsing from types (or objects) the parsible name normally uses a "." navigation separator, so that it is of the form  [class].[member].[memberOfMember]. ...)</g:documentation>
+  </g:annotation>
+  <g:body>
+  
+    <g:element g:targetName="gco:aName" g:minOccurs="1" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+    
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/UnitOfMeasure_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/UnitOfMeasure_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gml/UnitDefinition.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/UnlimitedInteger.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/UnlimitedInteger.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gco:UnlimitedInteger" 
+           g:extends="$base/schema/gco/basicTypes/UnlimitedInteger_Type.xml"/> 

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/UnlimitedInteger_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/UnlimitedInteger_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/xtn/Wrapped_BasicPropertyType.xml">
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gco/basicTypes/UnlimitedInteger.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/UnlimitedInteger_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/UnlimitedInteger_Type.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/core/xml/Element.xml"> 
+  <g:body>
+    <g:attribute g:targetNS="" g:targetName="isInfinite" g:valueType="xs:boolean"
+       g:extends="$base/core/xml/Attribute.xml"/>
+    <g:textNode g:extends="$base/core/xml/TextNode.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/UomAngle_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/UomAngle_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gml/UnitDefinition.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/UomArea_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/UomArea_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gml/UnitDefinition.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/UomLength_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/UomLength_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gml/UnitDefinition.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/UomScale_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/UomScale_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gml/UnitDefinition.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/UomTime_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/UomTime_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gml/UnitDefinition.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/UomVelocity_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/UomVelocity_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gml/UnitDefinition.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/UomVolume_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/basicTypes/UomVolume_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gml/UnitDefinition.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/gcoBase/AbstractObject_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/gcoBase/AbstractObject_Type.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>         
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/xtn/ui/UI_AbstractObject_Type.xml">
+  <g:body>
+    <g:import g:src="$base/schema/gco/gcoBase/ObjectIdentification.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/gcoBase/CodeListValue_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/gcoBase/CodeListValue_Type.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/xtn/ui/UI_CodeListValue_Type.xml"
+           g:isIsoCLV="true">    
+  <g:body>
+    <!-- 
+    <g:attribute g:targetNS="" g:targetName="codeSpace" g:use="optional" g:valueType="xs:anyURI"/>
+    <g:attribute g:targetNS="" g:targetName="codeList" g:use="required" g:valueType="xs:anyURI"/>
+    <g:attribute g:targetNS="" g:targetName="codeListValue" g:use="required" g:valueType="xs:anyURI"/>
+    -->
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/gcoBase/ObjectIdentification.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/gcoBase/ObjectIdentification.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>         
+<g:attributeGroup xmlns:g="http://www.esri.com/geoportal/gxe" 
+                  xmlns:h="http://www.esri.com/geoportal/gxe/html">
+  
+  <g:attribute g:targetNS="" g:targetName="id" g:valueType="xs:ID"
+    g:label="i18n:catalog.iso19139.gco.ObjectIdentification.id"
+    g:extends="$base/xtn/ui/UI_Expert_Attribute.xml"/>
+    
+  <g:attribute g:targetNS="" g:targetName="uuid" 
+    g:label="i18n:catalog.iso19139.gco.ObjectIdentification.uuid"
+    g:extends="$base/xtn/ui/UI_Expert_Attribute.xml"/>
+  
+</g:attributeGroup>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/gcoBase/ObjectReference.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/gcoBase/ObjectReference.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>         
+<g:attributeGroup xmlns:g="http://www.esri.com/geoportal/gxe" 
+                  xmlns:h="http://www.esri.com/geoportal/gxe/html">
+ 
+  <!-- 
+  TODO
+  
+  <xs:attributeGroup name="ObjectReference">
+    <xs:attributeGroup ref="xlink:simpleLink"/>
+    <xs:attribute name="uuidref" type="xs:string"/>
+  </xs:attributeGroup>
+   -->
+  
+  <g:attribute g:targetNS="" g:targetName="uuidref"
+    g:label="i18n:catalog.iso19139.gco.ObjectReference.uuidref"
+    g:extends="$base/xtn/ui/UI_Expert_Attribute.xml"/>
+  
+</g:attributeGroup>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/gcoBase/ObjectReference_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/gcoBase/ObjectReference_PropertyType.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:minOccurs="0" g:maxOccurs="1"
+           g:extends="$base/xtn/ui/UI_ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:import g:src="$base/schema/gco/gcoBase/ObjectReference.xml"/>
+    <g:attribute g:extends="$base/schema/gco/gcoBase/nilReason.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/gcoBase/codeList.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/gcoBase/codeList.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>         
+<g:attribute xmlns:g="http://www.esri.com/geoportal/gxe" 
+             xmlns:h="http://www.esri.com/geoportal/gxe/html"
+             g:targetNS="" g:targetName="codeList" 
+             g:use="required" g:valueType="xs:anyURI"
+             g:label="$i18n.catalog.iso19139.gco.CodeListValue.codeList" 
+             g:extends="$base/xtn/ui/UI_Attribute.xml"
+             g:rendered="false">
+  <!-- TODO rendering should be turned on for experts -->
+</g:attribute>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/gcoBase/codeListValue.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/gcoBase/codeListValue.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>         
+<g:attribute xmlns:g="http://www.esri.com/geoportal/gxe" 
+             xmlns:h="http://www.esri.com/geoportal/gxe/html"
+             h:class="gxeWrappedAttribute"
+             g:targetNS="" g:targetName="codeListValue" 
+             g:use="required" g:valueType="xs:anyURI"
+             g:label="$i18n.catalog.iso19139.gco.CodeListValue.codeListValue" 
+             g:extends="$base/xtn/ui/UI_Attribute.xml">
+  <g:header g:rendered="$editor.isExpertMode"></g:header>
+</g:attribute>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/gcoBase/codeSpace.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/gcoBase/codeSpace.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>         
+<g:attribute xmlns:g="http://www.esri.com/geoportal/gxe" 
+             xmlns:h="http://www.esri.com/geoportal/gxe/html"
+             g:targetNS="" g:targetName="codeSpace" 
+             g:use="optional" g:valueType="xs:anyURI"
+             g:label="$i18n.catalog.iso19139.gco.CodeListValue.codeSpace" 
+             g:extends="$base/xtn/ui/UI_Expert_Attribute.xml" 
+             g:rendered="false">
+  <!-- TODO rendering should be turned on for experts -->
+</g:attribute>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/gcoBase/isoType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/gcoBase/isoType.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>         
+<g:attribute xmlns:g="http://www.esri.com/geoportal/gxe" 
+             xmlns:h="http://www.esri.com/geoportal/gxe/html" 
+             g:targetName="gco:isoType"
+             g:extends="$base/xtn/ui/UI_Attribute.xml"/>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/gcoBase/nilReason.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/gcoBase/nilReason.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>         
+<g:attribute xmlns:g="http://www.esri.com/geoportal/gxe" 
+             xmlns:h="http://www.esri.com/geoportal/gxe/html" 
+             g:targetName="gco:nilReason"
+             g:extends="$base/xtn/ui/UI_Expert_Attribute.xml"/>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/xtn/Wrapped_BasicPropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/xtn/Wrapped_BasicPropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/xtn/ui/UI_Wrapped_Basic_PropertyType.xml">
+  <g:body>    
+    <g:attribute g:extends="$base/schema/gco/gcoBase/nilReason.xml"/>
+  </g:body>   
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/xtn/Wrapped_CodePropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gco/xtn/Wrapped_CodePropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/xtn/ui/UI_Code_PropertyType.xml"> 
+  <g:body>
+    <g:attribute g:extends="$base/schema/gco/gcoBase/nilReason.xml"/>
+  </g:body>  
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gcr/spatialReferencing/SC_CRS_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gcr/spatialReferencing/SC_CRS_PropertyType.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">
+  <g:body>
+    <!--
+    <g:element g:minOccurs="0" g:extends="$base/schema/gmd/referenceSystem/AbstractCRS.xml"/>
+    -->
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gfc/identification/AbstractMD_Identification.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gfc/identification/AbstractMD_Identification.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:AbstractMD_Identification" 
+           g:extends="$base/schema/gmd/identification/AbstractMD_Identification_Type.xml"/> 

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gfc/identification/AbstractMD_Identification_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gfc/identification/AbstractMD_Identification_Type.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/AbstractObject_Type.xml">
+  <g:annotation>
+    <g:documentation>Basic information about data</g:documentation>
+  </g:annotation>
+  <g:body>
+  
+    <g:tabs g:extends="$base/xtn/ui/UI_Tabs.xml">
+      <g:body>
+		    <g:element g:targetName="gmd:citation" g:minOccurs="1" g:maxOccurs="1"
+		      g:label="$i18n.catalog.iso19139.AbstractMD_Identification.citation"
+		      g:extends="$base/schema/gmd/citation/CI_Citation_PropertyType.xml"/>
+		      
+		    <g:element g:targetName="gmd:abstract" g:minOccurs="1" g:maxOccurs="1"
+		      g:label="$i18n.catalog.iso19139.AbstractMD_Identification.abstract"
+		      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml">
+		      <g:body>
+		        <g:element>
+		          <g:body>
+		            <g:input g:extends="$base/core/ui/InputTextArea.xml"/>
+		          </g:body>
+		        </g:element>
+		      </g:body>
+		    </g:element>
+		      
+		    <g:element g:targetName="gmd:purpose" g:minOccurs="0" g:maxOccurs="1"
+		      g:label="$i18n.catalog.iso19139.AbstractMD_Identification.purpose"
+		      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+		      
+		    <g:element g:targetName="gmd:credit" g:minOccurs="0" g:maxOccurs="unbounded"
+		      g:label="$i18n.catalog.iso19139.AbstractMD_Identification.credit"
+		      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+		      
+		    <g:element g:targetName="gmd:status" g:minOccurs="0" g:maxOccurs="unbounded"
+		      g:label="$i18n.catalog.iso19139.AbstractMD_Identification.status"
+		      g:extends="$base/schema/gmd/identification/MD_ProgressCode_PropertyType.xml"/>
+		      
+        <g:element g:targetName="gmd:pointOfContact" g:minOccurs="0" g:maxOccurs="unbounded"
+          g:label="$i18n.catalog.iso19139.AbstractMD_Identification.pointOfContact"
+          g:extends="$base/schema/gmd/citation/CI_ResponsibleParty_PropertyType.xml"/>
+          
+        <g:element g:targetName="gmd:resourceMaintenance" g:minOccurs="0" g:maxOccurs="unbounded"
+          g:label="$i18n.catalog.iso19139.AbstractMD_Identification.resourceMaintenance"
+          g:extends="$base/schema/gmd/maintenance/MD_MaintenanceInformation_PropertyType.xml"/>
+ 
+        <g:element g:targetName="gmd:graphicOverview" g:minOccurs="0" g:maxOccurs="unbounded"
+          g:label="$i18n.catalog.iso19139.AbstractMD_Identification.graphicOverview"
+          g:extends="$base/schema/gmd/identification/MD_BrowseGraphic_PropertyType.xml"/>     
+           
+        <g:tabs g:extends="$base/xtn/ui/UI_Tabs.xml" g:label="$i18n.catalog.gxe.general.more">
+          <g:body>  
+       
+				    <g:element g:targetName="gmd:resourceFormat" g:minOccurs="0" g:maxOccurs="unbounded"
+				      g:label="$i18n.catalog.iso19139.AbstractMD_Identification.resourceFormat"
+				      g:extends="$base/schema/gmd/distribution/MD_Format_PropertyType.xml"/>
+				
+				    <g:element g:targetName="gmd:descriptiveKeywords" g:minOccurs="0" g:maxOccurs="unbounded"
+				      g:label="$i18n.catalog.iso19139.AbstractMD_Identification.descriptiveKeywords"
+				      g:extends="$base/schema/gmd/identification/MD_Keywords_PropertyType.xml"/>
+				      
+				    <g:element g:targetName="gmd:resourceSpecificUsage" g:minOccurs="0" g:maxOccurs="unbounded"
+				      g:label="$i18n.catalog.iso19139.AbstractMD_Identification.resourceSpecificUsage"
+				      g:extends="$base/schema/gmd/identification/MD_Usage_PropertyType.xml"/>
+
+                    <g:element g:targetName="gmd:resourceConstraints" minOccurs="0" maxOccurs="unbounded"
+                      g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">
+                        <g:body>
+                          <g:elementChoice g:minOccurs="0" g:extends="$base/xtn/ui/UI_ElementChoice.xml">
+                            <g:body>
+                              <g:import g:src="$base/schema/gmd/constraints/MD_Constraints.xml"/>
+                              <g:import g:src="$base/schema/gmd/constraints/MD_LegalConstraints.xml"/>
+                              <g:import g:src="$base/schema/gmd/constraints/MD_SecurityConstraints.xml"/>
+                            </g:body>
+                          </g:elementChoice>
+                        </g:body>
+                    </g:element>
+				      
+				    <g:element g:targetName="gmd:aggregationInfo" g:minOccurs="0" g:maxOccurs="unbounded"
+				      g:label="$i18n.catalog.iso19139.AbstractMD_Identification.aggregationInfo"
+				      g:extends="$base/schema/gmd/identification/MD_AggregateInformation_PropertyType.xml"/>
+ 
+	        </g:body>
+	      </g:tabs>
+         
+      </g:body>
+    </g:tabs>
+          
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gfc/identification/MD_DataIdentification.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gfc/identification/MD_DataIdentification.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_DataIdentification" 
+           g:extends="$base/schema/gfc/identification/MD_DataIdentification_Type.xml"/> 

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gfc/identification/MD_DataIdentification_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gfc/identification/MD_DataIdentification_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" 
+      g:extends="$base/schema/gmd/identification/MD_DataIdentification.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gfc/identification/MD_DataIdentification_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gfc/identification/MD_DataIdentification_Type.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.MD_DataIdentification" g:label="$i18nBase"
+           g:extends="$base/schema/gfc/identification/AbstractMD_Identification_Type.xml">
+  <g:body>
+  
+        <g:tabs>
+          <g:body>
+          
+            <g:element g:targetName="gmd:spatialRepresentationType" g:minOccurs="0" g:maxOccurs="unbounded"
+              g:extends="$base/schema/gmd/identification/MD_SpatialRepresentationTypeCode_PropertyType.xml"/>
+
+            <g:element g:targetName="gmd:spatialResolution" g:minOccurs="0" g:maxOccurs="unbounded"
+              g:extends="$base/schema/gmd/identification/MD_Resolution_PropertyType.xml"/>
+
+            <g:tabs g:extends="$base/xtn/ui/UI_Tabs.xml" g:label="$i18n.catalog.gxe.general.more">
+              <g:body>  
+						      
+						    <g:element g:targetName="gmd:language" g:minOccurs="1" g:maxOccurs="unbounded"
+						      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+						      
+						    <g:element g:targetName="gmd:characterSet" g:minOccurs="0" g:maxOccurs="unbounded"
+						      g:extends="$base/schema/gmd/identification/MD_CharacterSetCode_PropertyType.xml"/>
+						      
+						    <g:element g:targetName="gmd:topicCategory" g:minOccurs="0" g:maxOccurs="unbounded"
+						      g:extends="$base/schema/gmd/identification/MD_TopicCategoryCode_PropertyType.xml"/>
+						      
+						    <g:element g:targetName="gmd:environmentDescription" g:minOccurs="0" g:maxOccurs="1"
+						      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+						    
+						    <g:element g:targetName="gmd:extent" g:minOccurs="0" g:maxOccurs="unbounded"
+						      g:extends="$base/schema/gmd/extent/EX_Extent_PropertyType.xml"/>
+						      
+						    <g:element g:targetName="gmd:supplementalInformation" g:minOccurs="0" g:maxOccurs="1"
+						      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+ 
+			        </g:body>
+            </g:tabs>
+    
+	        </g:body>
+	      </g:tabs>
+    
+             
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gfc/identification/MD_Resolution.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gfc/identification/MD_Resolution.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_Resolution" 
+           g:extends="$base/schema/gmd/identification/MD_Resolution_Type.xml"/> 

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gfc/identification/MD_Resolution_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gfc/identification/MD_Resolution_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/xtn/Wrapped_BasicPropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" 
+      g:extends="$base/schema/gmd/identification/MD_Resolution.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gfc/identification/MD_Resolution_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gfc/identification/MD_Resolution_Type.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.MD_Resolution" g:label="$i18nBase"
+           g:extends="$base/xtn/ui/UI_Wrapped_Element.xml">
+  <g:body>
+  
+    <g:elementChoice g:minOccurs="1" g:extends="$base/xtn/ui/UI_ElementChoice.xml">
+      <g:body>
+      
+        <g:element g:targetName="gmd:equivalentScale" g:minOccurs="1" g:maxOccurs="1"
+          g:extends="$base/schema/gmd/identification/MD_RepresentativeFraction_PropertyType.xml"/>
+    
+        <g:element g:targetName="gmd:distance" g:minOccurs="1" g:maxOccurs="1"
+          g:extends="$base/schema/gco/basicTypes/Distance_PropertyType.xml"/>      
+  
+      </g:body>
+    </g:elementChoice>      
+    
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gfc/identification/MD_SpatialRepresentationTypeCode.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gfc/identification/MD_SpatialRepresentationTypeCode.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_SpatialRepresentationTypeCode" 
+           g:i18nBase="catalog.iso19139.MD_SpatialRepresentationTypeCode" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/CodeListValue_Type.xml">
+  <g:body>
+   
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeSpace.xml" 
+      g:value="ISOTC211/19115"/>
+       
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeList.xml"
+      g:value="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_SpatialRepresentationTypeCode"/>
+     
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeListValue.xml">
+      <g:body>
+        <g:input g:extends="$base/core/ui/InputSelectOne.xml">
+          <g:options>
+            <g:option g:label="" g:value=""/>
+            <g:option g:label="$i18nBase.vector" g:value="vector"/>
+            <g:option g:label="$i18nBase.grid" g:value="grid"/>
+            <g:option g:label="$i18nBase.textTable" g:value="textTable"/>
+            <g:option g:label="$i18nBase.tin" g:value="tin"/>
+            <g:option g:label="$i18nBase.stereoModel" g:value="stereoModel"/>
+            <g:option g:label="$i18nBase.video" g:value="video"/>
+          </g:options>
+        </g:input>
+      </g:body>          
+    </g:attribute>     
+     
+  </g:body> 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gfc/identification/MD_SpatialRepresentationTypeCode_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gfc/identification/MD_SpatialRepresentationTypeCode_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/xtn/Wrapped_CodePropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" 
+      g:extends="$base/schema/gmd/identification/MD_SpatialRepresentationTypeCode.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/applicationSchema/MD_ApplicationSchemaInformation.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/applicationSchema/MD_ApplicationSchemaInformation.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_ApplicationSchemaInformation" 
+           g:extends="$base/schema/gmd/applicationSchema/MD_ApplicationSchemaInformation_Type.xml"> 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/applicationSchema/MD_ApplicationSchemaInformation_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/applicationSchema/MD_ApplicationSchemaInformation_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gmd/applicationSchema/MD_ApplicationSchemaInformation.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/applicationSchema/MD_ApplicationSchemaInformation_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/applicationSchema/MD_ApplicationSchemaInformation_Type.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.MD_ApplicationSchemaInformation" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/AbstractObject_Type.xml">
+  <g:annotation>
+    <g:documentation>Information about the application schema used to build the dataset</g:documentation>
+  </g:annotation>
+  <g:body>
+  
+    <g:element g:targetName="gmd:name" g:minOccurs="1" g:maxOccurs="1"
+      g:extends="$base/schema/gmd/citation/CI_Citation_PropertyType.xml"/>
+    
+    <g:element g:targetName="gmd:schemaLanguage" g:minOccurs="1" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+    
+    <g:element g:targetName="gmd:constraintLanguage" g:minOccurs="1" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+    
+    <g:element g:targetName="gmd:schemaAscii" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+    
+    <g:element g:targetName="gmd:graphicsFile" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/Binary_PropertyType.xml"/>
+      
+    <g:element g:targetName="gmd:softwareDevelopmentFile" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/Binary_PropertyType.xml"/>
+    
+    <g:element g:targetName="gmd:softwareDevelopmentFileFormat" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+    
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_Address.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_Address.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:CI_Address" 
+           g:extends="$base/schema/gmd/citation/CI_Address_Type.xml"> 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_Address_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_Address_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gmd/citation/CI_Address.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_Address_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_Address_Type.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.CI_Address" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/AbstractObject_Type.xml">
+  <g:body>
+  
+    <g:element g:targetName="gmd:deliveryPoint" g:minOccurs="0" g:maxOccurs="unbounded"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+    
+    <g:element g:targetName="gmd:city" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+    
+    <g:element g:targetName="gmd:administrativeArea" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+    
+    <g:element g:targetName="gmd:postalCode" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+    
+    <g:element g:targetName="gmd:country" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+    
+    <g:element g:targetName="gmd:electronicMailAddress" g:minOccurs="0" g:maxOccurs="unbounded"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+    
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_Citation.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_Citation.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:CI_Citation" 
+           g:extends="$base/schema/gmd/citation/CI_Citation_Type.xml"> 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_Citation_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_Citation_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gmd/citation/CI_Citation.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_Citation_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_Citation_Type.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.CI_Citation" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/AbstractObject_Type.xml">
+  <g:body>
+  
+    <g:element g:targetName="gmd:title" g:minOccurs="1" g:maxOccurs="1" 
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+        
+    <g:tabs g:extends="$base/xtn/ui/UI_Tabs.xml">
+      <g:body>
+      
+        <g:element g:targetName="gmd:alternateTitle" g:minOccurs="0" g:maxOccurs="unbounded"
+          g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+
+		    <g:element g:targetName="gmd:date" g:minOccurs="1" g:maxOccurs="unbounded"
+		      g:extends="$base/schema/gmd/citation/CI_Date_PropertyType.xml"/>		
+		      
+		    <g:element g:targetName="gmd:edition" g:minOccurs="0" g:maxOccurs="1"
+		      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+		    
+		    <g:element g:targetName="gmd:editionDate" g:minOccurs="0" g:maxOccurs="1"
+		      g:extends="$base/schema/gco/basicTypes/Date_PropertyType.xml"/>
+		      
+		    <g:tabs g:extends="$base/xtn/ui/UI_Tabs.xml" g:label="$i18n.catalog.gxe.general.more">
+          <g:body>   
+		      
+		        <g:element g:targetName="gmd:identifier" g:minOccurs="0" g:maxOccurs="unbounded"
+              g:extends="$base/schema/gmd/referenceSystem/MD_Identifier_PropertyType.xml"/>
+                         
+            <g:element g:targetName="gmd:citedResponsibleParty" g:minOccurs="0" g:maxOccurs="unbounded"
+              g:extends="$base/schema/gmd/citation/CI_ResponsibleParty_PropertyType.xml"/>
+		      
+		        <g:element g:targetName="gmd:presentationForm" g:minOccurs="0" g:maxOccurs="unbounded"
+		          g:extends="$base/schema/gmd/citation/CI_PresentationFormCode_PropertyType.xml"/>
+		        
+				    <g:tabs g:extends="$base/xtn/ui/UI_Tabs.xml" g:label="$i18n.catalog.gxe.general.more">
+		          <g:body>   
+				        <g:element g:targetName="gmd:series" g:minOccurs="0" g:maxOccurs="1"
+				          g:extends="$base/schema/gmd/citation/CI_Series_PropertyType.xml"/>
+				      
+								<g:element g:targetName="gmd:otherCitationDetails" g:minOccurs="0" g:maxOccurs="1"
+						      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+						    
+						    <g:element g:targetName="gmd:ISBN" g:minOccurs="0" g:maxOccurs="1"
+						      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+						    
+						    <g:element g:targetName="gmd:ISSN" g:minOccurs="0" g:maxOccurs="1"
+						      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+						      
+						  </g:body>
+		        </g:tabs>
+      
+		      </g:body>
+		    </g:tabs>
+      
+      </g:body>
+    </g:tabs>
+    
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_Contact.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_Contact.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:CI_Contact" 
+           g:extends="$base/schema/gmd/citation/CI_Contact_Type.xml"> 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_Contact_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_Contact_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gmd/citation/CI_Contact.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_Contact_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_Contact_Type.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.CI_Contact" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/AbstractObject_Type.xml">
+  <g:body>
+  
+    <g:tabs g:extends="$base/xtn/ui/UI_Tabs.xml">
+      <g:body>
+		    <g:element g:targetName="gmd:phone" g:minOccurs="0" g:maxOccurs="1"
+		      g:extends="$base/schema/gmd/citation/CI_Telephone_PropertyType.xml"/>
+		      
+		    <g:element g:targetName="gmd:address" g:minOccurs="0" g:maxOccurs="1"
+		      g:extends="$base/schema/gmd/citation/CI_Address_PropertyType.xml"/>
+		      
+		    <g:element g:targetName="gmd:onlineResource" g:minOccurs="0" g:maxOccurs="1"
+		      g:extends="$base/schema/gmd/citation/CI_OnlineResource_PropertyType.xml"/>
+		      
+		    <g:element g:targetName="gmd:hoursOfService" g:minOccurs="0" g:maxOccurs="1"
+          g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+    
+        <g:element g:targetName="gmd:contactInstructions" g:minOccurs="0" g:maxOccurs="1"
+          g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>  
+          
+		  </g:body>
+		</g:tabs>
+    
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_Date.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_Date.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:CI_Date" 
+           g:extends="$base/schema/gmd/citation/CI_Date_Type.xml"> 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_DateTypeCode.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_DateTypeCode.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:CI_DateTypeCode" 
+           g:i18nBase="catalog.iso19139.CI_DateTypeCode" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/CodeListValue_Type.xml">
+  <g:body>
+   
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeSpace.xml" 
+      g:value="ISOTC211/19115"/>
+       
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeList.xml"
+      g:value="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode"/>
+     
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeListValue.xml">
+      <g:body>
+        <g:input g:extends="$base/core/ui/InputSelectOne.xml">
+          <g:options>
+            <g:option g:label="" g:value="" />
+            <g:option g:label="$i18nBase.creation" g:value="creation" />
+            <g:option g:label="$i18nBase.publication" g:value="publication" g:selected="true"/>
+            <g:option g:label="$i18nBase.revision" g:value="revision"/>
+          </g:options>
+        </g:input>
+      </g:body>          
+    </g:attribute>     
+     
+  </g:body> 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_DateTypeCode_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_DateTypeCode_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/xtn/Wrapped_CodePropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gmd/citation/CI_DateTypeCode.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_Date_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_Date_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gmd/citation/CI_Date.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_Date_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_Date_Type.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.CI_Date" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/AbstractObject_Type.xml">
+  <g:body>
+  
+    <g:element g:targetName="gmd:date" g:minOccurs="1" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/Date_PropertyType.xml">
+      <!-- <g:header g:rendered="$editor.isExpertMode"></g:header> -->
+    </g:element>
+    
+    <g:element g:targetName="gmd:dateType" g:minOccurs="1" g:maxOccurs="1"
+      g:extends="$base/schema/gmd/citation/CI_DateTypeCode_PropertyType.xml"/>
+  
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_OnLineFunctionCode.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_OnLineFunctionCode.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:CI_OnLineFunctionCode" 
+           g:i18nBase="catalog.iso19139.CI_OnLineFunctionCode" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/CodeListValue_Type.xml">
+  <g:body>
+   
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeSpace.xml" 
+      g:value="ISOTC211/19115"/>
+       
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeList.xml"
+      g:value="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_OnLineFunctionCode"/>
+     
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeListValue.xml">
+      <g:body>
+        <g:input g:extends="$base/core/ui/InputSelectOne.xml">
+          <g:options>
+            <g:option g:label="" g:value="" />
+            <g:option g:label="$i18nBase.download" g:value="download" />
+            <g:option g:label="$i18nBase.information" g:value="information"/>
+            <g:option g:label="$i18nBase.offlineAccess" g:value="offlineAccess"/>
+            <g:option g:label="$i18nBase.order" g:value="order"/>
+            <g:option g:label="$i18nBase.search" g:value="search"/>
+          </g:options>
+        </g:input>
+      </g:body>          
+    </g:attribute>     
+     
+  </g:body> 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_OnLineFunctionCode_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_OnLineFunctionCode_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/xtn/Wrapped_CodePropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gmd/citation/CI_OnLineFunctionCode.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_OnlineResource.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_OnlineResource.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:CI_OnlineResource" 
+           g:extends="$base/schema/gmd/citation/CI_OnlineResource_Type.xml"> 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_OnlineResource_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_OnlineResource_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gmd/citation/CI_OnlineResource.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_OnlineResource_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_OnlineResource_Type.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.CI_OnlineResource" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/AbstractObject_Type.xml">
+  <g:body>
+  
+    <g:element g:targetName="gmd:linkage" g:minOccurs="1" g:maxOccurs="1"
+      g:extends="$base/schema/gmd/citation/URL_PropertyType.xml"/>
+    
+    <g:element g:targetName="gmd:protocol" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+    
+    <g:element g:targetName="gmd:applicationProfile" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+    
+    <g:element g:targetName="gmd:name" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+    
+    <g:element g:targetName="gmd:description" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+    
+    <g:element g:targetName="gmd:function" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gmd/citation/CI_OnLineFunctionCode_PropertyType.xml"/>
+    
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_PresentationFormCode.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_PresentationFormCode.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:CI_PresentationFormCode" 
+           g:i18nBase="catalog.iso19139.CI_PresentationFormCode" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/CodeListValue_Type.xml">
+  <g:body>
+   
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeSpace.xml" 
+      g:value="ISOTC211/19115"/>
+       
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeList.xml"
+      g:value="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_PresentationFormCode"/>
+     
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeListValue.xml">
+      <g:body>
+        <g:input g:extends="$base/core/ui/InputSelectOne.xml">
+          <g:options>
+            <g:option g:label="" g:value="" />
+            <g:option g:label="$i18nBase.documentDigital" g:value="documentDigital"/>
+            <g:option g:label="$i18nBase.documentHardcopy" g:value="documentHardcopy"/>
+            <g:option g:label="$i18nBase.imageDigital" g:value="imageDigital"/>
+            <g:option g:label="$i18nBase.imageHardcopy" g:value="imageHardcopy"/>
+            <g:option g:label="$i18nBase.mapDigital" g:value="mapDigital"/>
+            <g:option g:label="$i18nBase.mapHardcopy" g:value="mapHardcopy"/>
+            <g:option g:label="$i18nBase.modelDigital" g:value="modelDigital"/>
+            <g:option g:label="$i18nBase.modelHardcopy" g:value="modelHardcopy"/>
+            <g:option g:label="$i18nBase.profileDigital" g:value="profileDigital"/>
+            <g:option g:label="$i18nBase.profileHardcopy" g:value="profileHardcopy"/>
+            <g:option g:label="$i18nBase.tableDigital" g:value="tableDigital"/>
+            <g:option g:label="$i18nBase.tableHardcopy" g:value="tableHardcopy"/>
+            <g:option g:label="$i18nBase.videoDigital" g:value="videoDigital"/>
+            <g:option g:label="$i18nBase.videoHardcopy" g:value="videoHardcopy"/>
+          </g:options>
+        </g:input>
+      </g:body>          
+    </g:attribute>     
+     
+  </g:body> 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_PresentationFormCode_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_PresentationFormCode_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/xtn/Wrapped_CodePropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gmd/citation/CI_PresentationFormCode.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_ResponsibleParty.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_ResponsibleParty.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:CI_ResponsibleParty" 
+           g:extends="$base/schema/gmd/citation/CI_ResponsibleParty_Type.xml"> 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_ResponsibleParty_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_ResponsibleParty_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gmd/citation/CI_ResponsibleParty.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_ResponsibleParty_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_ResponsibleParty_Type.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.CI_ResponsibleParty" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/AbstractObject_Type.xml">
+  <g:body>
+  
+    <g:element g:targetName="gmd:individualName" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+
+    <g:element g:targetName="gmd:organisationName" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+          
+    <g:element g:targetName="gmd:positionName" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+
+    <g:tabs g:extends="$base/xtn/ui/UI_Tabs.xml">
+	    <g:body>
+		      
+		    <g:element g:targetName="gmd:contactInfo" g:minOccurs="0" g:maxOccurs="1"
+		      g:extends="$base/schema/gmd/citation/CI_Contact_PropertyType.xml"/>
+		    
+		    <g:element g:targetName="gmd:role" g:minOccurs="1" g:maxOccurs="1"
+		      g:extends="$base/schema/gmd/citation/CI_RoleCode_PropertyType.xml"/>
+      
+      </g:body>
+    </g:tabs>
+
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_RoleCode.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_RoleCode.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:CI_RoleCode" 
+           g:i18nBase="catalog.iso19139.CI_RoleCode" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/CodeListValue_Type.xml">
+  <g:body>
+   
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeSpace.xml" 
+      g:value="ISOTC211/19115"/>
+       
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeList.xml"
+      g:value="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_RoleCode"/>
+     
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeListValue.xml">
+      <g:body>
+        <g:input g:extends="$base/core/ui/InputSelectOne.xml">
+          <g:options>
+            <g:option g:label="" g:value="" />
+            <g:option g:label="$i18nBase.resourceProvider" g:value="resourceProvider" />
+            <g:option g:label="$i18nBase.custodian" g:value="custodian"/>
+            <g:option g:label="$i18nBase.owner" g:value="owner"/>
+            <g:option g:label="$i18nBase.user" g:value="user"/>
+            <g:option g:label="$i18nBase.distributor" g:value="distributor"/>
+            <g:option g:label="$i18nBase.originator" g:value="originator"/>
+            <g:option g:label="$i18nBase.pointOfContact" g:value="pointOfContact" g:selected="true"/>
+            <g:option g:label="$i18nBase.principalInvestigator" g:value="principalInvestigator"/>
+            <g:option g:label="$i18nBase.processor" g:value="processor"/>
+            <g:option g:label="$i18nBase.publisher" g:value="publisher"/>
+            <g:option g:label="$i18nBase.author" g:value="author"/>
+          </g:options>
+        </g:input>
+      </g:body>          
+    </g:attribute>     
+     
+  </g:body> 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_RoleCode_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_RoleCode_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/xtn/Wrapped_CodePropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gmd/citation/CI_RoleCode.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_Series.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_Series.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:CI_Series" 
+           g:extends="$base/schema/gmd/citation/CI_Series_Type.xml"> 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_Series_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_Series_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gmd/citation/CI_Series.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_Series_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_Series_Type.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.CI_Series" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/AbstractObject_Type.xml">
+  <g:body>
+  
+    <g:element g:targetName="gmd:name" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+    
+    <g:element g:targetName="gmd:issueIdentification" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+    
+    <g:element g:targetName="gmd:page" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+    
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_Telephone.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_Telephone.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:CI_Telephone" 
+           g:extends="$base/schema/gmd/citation/CI_Telephone_Type.xml"> 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_Telephone_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_Telephone_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gmd/citation/CI_Telephone.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_Telephone_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/CI_Telephone_Type.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.CI_Telephone" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/AbstractObject_Type.xml">
+  <g:body>
+  
+    <g:element g:targetName="gmd:voice" g:minOccurs="0" g:maxOccurs="unbounded"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+    
+    <g:element g:targetName="gmd:facsimile" g:minOccurs="0" g:maxOccurs="unbounded"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+    
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/URL.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/URL.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:URL" g:valueType="xs:anyURI"
+           g:extends="$base/xtn/ui/UI_Wrapped_ElementTextOnly.xml"> 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/URL_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/citation/URL_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/xtn/Wrapped_BasicPropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="$parent" g:extends="$base/schema/gmd/citation/URL.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/constraints/MD_ClassificationCode.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/constraints/MD_ClassificationCode.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_ClassificationCode"
+           g:i18nBase="catalog.iso19139.MD_ClassificationCode" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/CodeListValue_Type.xml">
+  <g:body>
+
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeSpace.xml"
+      g:value="ISOTC211/19115"/>
+
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeList.xml"
+      g:value="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_ClassificationCode"/>
+
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeListValue.xml">
+      <g:body>
+        <g:input g:extends="$base/core/ui/InputSelectOne.xml">
+          <g:options>
+            <g:option g:label="" g:value="" />
+            <g:option g:label="$i18nBase.unclassified" g:value="unclassified" />
+            <g:option g:label="$i18nBase.restricted" g:value="restricted"/>
+            <g:option g:label="$i18nBase.confidential" g:value="confidential"/>
+            <g:option g:label="$i18nBase.secret" g:value="secret"/>
+            <g:option g:label="$i18nBase.topSecret" g:value="topSecret"/>
+          </g:options>
+        </g:input>
+      </g:body>
+    </g:attribute>
+
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/constraints/MD_ClassificationCode_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/constraints/MD_ClassificationCode_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/xtn/Wrapped_BasicPropertyType.xml">
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gmd/constraints/MD_ClassificationCode.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/constraints/MD_Constraints.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/constraints/MD_Constraints.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_Constraints"
+           g:extends="$base/schema/gmd/constraints/MD_Constraints_Type.xml">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/constraints/MD_Constraints_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/constraints/MD_Constraints_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gmd/constraints/MD_Constraints.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/constraints/MD_Constraints_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/constraints/MD_Constraints_Type.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:label="$i18n.catalog.iso19139.MD_Constraints" 
+           g:extends="$base/schema/gco/gcoBase/AbstractObject_Type.xml">
+  <g:body>
+
+    <g:element g:targetName="gmd:useLimitation" g:minOccurs="0" g:maxOccurs="unbounded"
+      g:label="$i18n.catalog.iso19139.MD_Constraints.useLimitation" 
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/constraints/MD_LegalConstraints.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/constraints/MD_LegalConstraints.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_LegalConstraints"
+           g:extends="$base/schema/gmd/constraints/MD_LegalConstraints_Type.xml">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/constraints/MD_LegalConstraints_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/constraints/MD_LegalConstraints_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gmd/constraints/MD_LegalConstraints.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/constraints/MD_LegalConstraints_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/constraints/MD_LegalConstraints_Type.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.MD_LegalConstraints" g:label="$i18nBase"
+           g:extends="$base/schema/gmd/constraints/MD_Constraints_Type.xml">
+  <g:body>
+
+    <g:element g:targetName="gmd:accessConstraints" g:minOccurs="0" g:maxOccurs="unbounded"
+      g:extends="$base/schema/gmd/constraints/MD_RestrictionCode_PropertyType.xml"/>
+
+    <g:element g:targetName="gmd:useConstraints" g:minOccurs="0" g:maxOccurs="unbounded"
+      g:extends="$base/schema/gmd/constraints/MD_RestrictionCode_PropertyType.xml"/>
+
+    <g:element g:targetName="gmd:otherConstraints" g:minOccurs="0" g:maxOccurs="unbounded"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/constraints/MD_RestrictionCode.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/constraints/MD_RestrictionCode.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_RestrictionCode"
+           g:i18nBase="catalog.iso19139.MD_RestrictionCode" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/CodeListValue_Type.xml">
+  <g:body>
+
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeSpace.xml"
+      g:value="ISOTC211/19115"/>
+
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeList.xml"
+      g:value="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_RestrictionCode"/>
+
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeListValue.xml">
+      <g:body>
+        <g:input g:extends="$base/core/ui/InputSelectOne.xml">
+          <g:options>
+            <g:option g:label="" g:value="" />
+            <g:option g:label="$i18nBase.copyright" g:value="copyright" />
+            <g:option g:label="$i18nBase.patent" g:value="patent"/>
+            <g:option g:label="$i18nBase.patentPending" g:value="patentPending"/>
+            <g:option g:label="$i18nBase.trademark" g:value="trademark"/>
+            <g:option g:label="$i18nBase.license" g:value="license"/>
+            <g:option g:label="$i18nBase.intellectualPropertyRights" g:value="intellectualPropertyRights"/>
+            <g:option g:label="$i18nBase.restricted" g:value="restricted"/>
+            <g:option g:label="$i18nBase.otherRestrictions" g:value="otherRestrictions"/>
+          </g:options>
+        </g:input>
+      </g:body>
+    </g:attribute>
+
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/constraints/MD_RestrictionCode_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/constraints/MD_RestrictionCode_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/xtn/Wrapped_CodePropertyType.xml">
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gmd/constraints/MD_RestrictionCode.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/constraints/MD_SecurityConstraints.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/constraints/MD_SecurityConstraints.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_SecurityConstraints"
+           g:extends="$base/schema/gmd/constraints/MD_SecurityConstraints_Type.xml">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/constraints/MD_SecurityConstraints_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/constraints/MD_SecurityConstraints_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gmd/constraints/MD_SecurityConstraints.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/constraints/MD_SecurityConstraints_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/constraints/MD_SecurityConstraints_Type.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.MD_SecurityConstraints" g:label="$i18nBase"
+           g:extends="$base/schema/gmd/constraints/MD_Constraints_Type.xml">
+  <g:body>
+
+    <g:element g:targetName="gmd:classification"
+      g:extends="$base/schema/gmd/constraints/MD_ClassificationCode_PropertyType.xml"/>
+
+    <g:element g:targetName="gmd:userNote" g:minOccurs="0"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+
+    <g:element g:targetName="gmd:classificationSystem" g:minOccurs="0"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+
+    <g:element g:targetName="gmd:handlingDescription" g:minOccurs="0"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/content/AbstractMD_ContentInformation.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/content/AbstractMD_ContentInformation.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:abstract="true"
+           g:extends="$base/schema/gmd/content/AbstractMD_ContentInformation_Type.xml">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/content/AbstractMD_ContentInformation_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/content/AbstractMD_ContentInformation_Type.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.AbstractMD_ContentInformation_Type" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/AbstractObject_Type.xml" g:abstract="true">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/content/MD_Band.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/content/MD_Band.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_Band"
+           g:extends="$base/schema/gmd/content/MD_Band_Type.xml">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/content/MD_Band_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/content/MD_Band_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:label="$i18n.catalog.iso19139.MD_Band"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">
+  <g:body>
+    <g:import g:minOccurs="0" g:src="$base/schema/gmd/content/MD_Band.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/content/MD_Band_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/content/MD_Band_Type.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.MD_Band" g:label="$i18nBase"
+           g:extends="$base/schema/gmd/content/MD_RangeDimension_Type.xml">
+  <g:body>
+    <g:element g:targetName="gmd:minValue" minOccurs="0"
+      g:extends="$base/schema/gco/basicTypes/Real_PropertyType.xml"/>
+
+    <g:element g:targetName="gmd:maxValue" minOccurs="0"
+      g:extends="$base/schema/gco/basicTypes/Real_PropertyType.xml"/>
+
+    <!-- TODO: provide gml/UnitDefinition.xml
+    <g:element g:targetName="gmd:units" minOccurs="0"
+      g:extends="$base/schema/gco/basicTypes/UomLength_PropertyType.xml"/>
+    -->
+
+    <g:element g:targetName="gmd:peakResponse" minOccurs="0"
+      g:extends="$base/schema/gco/basicTypes/Real_PropertyType.xml"/>
+
+    <g:element g:targetName="gmd:bitsPerValue" minOccurs="0"
+      g:extends="$base/schema/gco/basicTypes/Integer_PropertyType.xml"/>
+
+    <g:element g:targetName="gmd:toneGradation" minOccurs="0"
+      g:extends="$base/schema/gco/basicTypes/Integer_PropertyType.xml"/>
+
+    <g:element g:targetName="gmd:scaleFactor" minOccurs="0"
+      g:extends="$base/schema/gco/basicTypes/Real_PropertyType.xml"/>
+
+    <g:element g:targetName="gmd:offset" minOccurs="0"
+      g:extends="$base/schema/gco/basicTypes/Real_PropertyType.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/content/MD_ContentInformation_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/content/MD_ContentInformation_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">
+  <g:body>
+    <g:import g:minOccurs="0" g:src="$base/schema/gmd/content/AbstractMD_ContentInformation.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/content/MD_CoverageContentTypeCode.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/content/MD_CoverageContentTypeCode.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_CoverageContentTypeCode"
+           g:i18nBase="catalog.iso19139.MD_CoverageContentTypeCode" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/CodeListValue_Type.xml">
+  <g:body>
+
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeSpace.xml"
+      g:value="ISOTC211/19115"/>
+
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeList.xml"
+      g:value="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_CoverageContentTypeCode"/>
+
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeListValue.xml">
+      <g:body>
+        <g:input g:extends="$base/core/ui/InputSelectOne.xml">
+          <g:options>
+            <g:option g:label="" g:value="" />
+            <g:option g:label="$i18nBase.image" g:value="image" />
+            <g:option g:label="$i18nBase.thematicClassification" g:value="thematicClassification"/>
+            <g:option g:label="$i18nBase.physicalMeasurement" g:value="physicalMeasurement"/>
+          </g:options>
+        </g:input>
+      </g:body>
+    </g:attribute>
+
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/content/MD_CoverageContentTypeCode_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/content/MD_CoverageContentTypeCode_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/xtn/Wrapped_CodePropertyType.xml">
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gmd/content/MD_CoverageContentTypeCode.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/content/MD_CoverageDescription.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/content/MD_CoverageDescription.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_CoverageDescription"
+           g:extends="$base/schema/gmd/content/MD_CoverageDescription_Type.xml">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/content/MD_CoverageDescription_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/content/MD_CoverageDescription_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">
+  <g:body>
+    <g:import g:minOccurs="0" g:src="$base/schema/gmd/content/MD_CoverageDescription.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/content/MD_CoverageDescription_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/content/MD_CoverageDescription_Type.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.MD_CoverageDescription" g:label="$i18nBase"
+           g:extends="$base/schema/gmd/content/AbstractMD_ContentInformation_Type.xml">
+  <g:body>
+    <g:element g:targetName="gmd:attributeDescription" minOccurs="0"
+      g:extends="$base/schema/gco/basicTypes/RecordType_PropertyType.xml"/>
+
+    <g:element g:targetName="gmd:contentType"
+      g:extends="$base/schema/gmd/content/MD_CoverageContentTypeCode_PropertyType.xml"/>
+
+    <g:element g:targetName="gmd:dimension" g:label="$i18n.catalog.iso19139.MD_CoverageDescription.dimension" minOccurs="0" maxOccurs="unbounded"
+      g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">
+        <g:body>
+          <g:elementChoice g:minOccurs="0" g:extends="$base/xtn/ui/UI_ElementChoice.xml">
+            <g:body>
+              <g:import g:src="$base/schema/gmd/content/MD_RangeDimension.xml"/>
+              <g:import g:src="$base/schema/gmd/content/MD_Band.xml"/>
+            </g:body>
+          </g:elementChoice>
+        </g:body>
+    </g:element>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/content/MD_FeatureCatalogueDescription.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/content/MD_FeatureCatalogueDescription.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_FeatureCatalogueDescription"
+           g:extends="$base/schema/gmd/content/MD_FeatureCatalogueDescription_Type.xml">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/content/MD_FeatureCatalogueDescription_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/content/MD_FeatureCatalogueDescription_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">
+  <g:body>
+    <g:import g:minOccurs="0" g:src="$base/schema/gmd/content/MD_FeatureCatalogueDescription.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/content/MD_FeatureCatalogueDescription_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/content/MD_FeatureCatalogueDescription_Type.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.MD_FeatureCatalogueDescription" g:label="$i18nBase"
+           g:extends="$base/schema/gmd/content/AbstractMD_ContentInformation_Type.xml">
+  <g:body>
+    <g:element g:targetName="gmd:complianceCode" minOccurs="0"
+      g:extends="$base/schema/gco/basicTypes/Boolean_PropertyType.xml"/>
+
+    <g:element g:targetName="gmd:language" minOccurs="0" maxOccurs="unbounded"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+
+    <g:element g:targetName="gmd:includedWithDataset"
+      g:extends="$base/schema/gco/basicTypes/Boolean_PropertyType.xml"/>
+
+    <g:element g:targetName="gmd:featureTypes"
+      g:extends="$base/schema/gco/basicTypes/GenericName_PropertyType.xml"/>
+
+    <g:element g:targetName="gmd:featureCatalogueCitation"
+      g:extends="$base/schema/gmd/citation/CI_Citation_PropertyType.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/content/MD_ImageDescription.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/content/MD_ImageDescription.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_ImageDescription"
+           g:extends="$base/schema/gmd/content/MD_ImageDescription_Type.xml">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/content/MD_ImageDescription_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/content/MD_ImageDescription_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:label="$i18n.catalog.iso19139.MD_ImageDescription"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">
+  <g:body>
+    <g:import g:minOccurs="0" g:src="$base/schema/gmd/content/MD_ImageDescription.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/content/MD_ImageDescription_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/content/MD_ImageDescription_Type.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.MD_ImageDescription" g:label="$i18nBase"
+           g:extends="$base/schema/gmd/content/MD_CoverageDescription_Type.xml">
+  <g:body>
+    <g:element g:targetName="gmd:illuminationElevationAngle" minOccurs="0"
+      g:extends="$base/schema/gco/basicTypes/Real_PropertyType.xml"/>
+
+    <g:element g:targetName="gmd:illuminationAzimuthAngle" minOccurs="0"
+      g:extends="$base/schema/gco/basicTypes/Real_PropertyType.xml"/>
+
+    <g:element g:targetName="gmd:imagingCondition" minOccurs="0"
+      g:extends="$base/schema/gmd/content/MD_ImagingConditionCode_PropertyType.xml"/>
+
+    <g:element g:targetName="gmd:imageQualityCode" g:minOccurs="0"
+      g:extends="$base/schema/gmd/referenceSystem/MD_Identifier_PropertyType.xml">
+    </g:element>
+
+    <g:element g:targetName="gmd:cloudCoverPercentage" minOccurs="0"
+      g:extends="$base/schema/gco/basicTypes/Real_PropertyType.xml"/>
+
+    <g:element g:targetName="gmd:processingLevelCode" g:minOccurs="0"
+      g:extends="$base/schema/gmd/referenceSystem/MD_Identifier_PropertyType.xml">
+    </g:element>
+
+    <g:element g:targetName="gmd:compressionGenerationQuantity" minOccurs="0"
+      g:extends="$base/schema/gco/basicTypes/Integer_PropertyType.xml"/>
+
+    <g:element g:targetName="gmd:triangulationIndicator" minOccurs="0"
+      g:extends="$base/schema/gco/basicTypes/Boolean_PropertyType.xml"/>
+
+    <g:element g:targetName="gmd:radiometricCalibrationDataAvailability" minOccurs="0"
+      g:extends="$base/schema/gco/basicTypes/Boolean_PropertyType.xml"/>
+
+    <g:element g:targetName="gmd:cameraCalibrationInformationAvailability" minOccurs="0"
+      g:extends="$base/schema/gco/basicTypes/Boolean_PropertyType.xml"/>
+
+    <g:element g:targetName="gmd:filmDistortionInformationAvailability" minOccurs="0"
+      g:extends="$base/schema/gco/basicTypes/Boolean_PropertyType.xml"/>
+
+    <g:element g:targetName="gmd:lensDistortionInformationAvailability" minOccurs="0"
+      g:extends="$base/schema/gco/basicTypes/Boolean_PropertyType.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/content/MD_ImagingConditionCode.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/content/MD_ImagingConditionCode.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_ImagingConditionCode"
+           g:i18nBase="catalog.iso19139.MD_ImagingConditionCode" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/CodeListValue_Type.xml">
+  <g:body>
+
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeSpace.xml"
+      g:value="ISOTC211/19115"/>
+
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeList.xml"
+      g:value="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_ImagingConditionCode"/>
+
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeListValue.xml">
+      <g:body>
+        <g:input g:extends="$base/core/ui/InputSelectOne.xml">
+          <g:options>
+            <g:option g:label="" g:value="" />
+            <g:option g:label="$i18nBase.blurredImage" g:value="blurredImage" />
+            <g:option g:label="$i18nBase.cloud" g:value="cloud" />
+            <g:option g:label="$i18nBase.degradingObliquity" g:value="degradingObliquity" />
+            <g:option g:label="$i18nBase.fog" g:value="fog" />
+            <g:option g:label="$i18nBase.heavySmokeOrDust" g:value="heavySmokeOrDust" />
+            <g:option g:label="$i18nBase.night" g:value="night" />
+            <g:option g:label="$i18nBase.rain" g:value="rain" />
+            <g:option g:label="$i18nBase.semiDarkness" g:value="semiDarkness" />
+            <g:option g:label="$i18nBase.shadow" g:value="shadow" />
+            <g:option g:label="$i18nBase.snow" g:value="snow" />
+          </g:options>
+        </g:input>
+      </g:body>
+    </g:attribute>
+
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/content/MD_ImagingConditionCode_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/content/MD_ImagingConditionCode_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/xtn/Wrapped_CodePropertyType.xml">
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gmd/content/MD_ImagingConditionCode.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/content/MD_RangeDimension.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/content/MD_RangeDimension.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_RangeDimension"
+           g:extends="$base/schema/gmd/content/MD_RangeDimension_Type.xml">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/content/MD_RangeDimension_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/content/MD_RangeDimension_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:label="$i18n.catalog.iso19139.MD_RangeDimension"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">
+  <g:body>
+    <g:import g:minOccurs="0" g:src="$base/schema/gmd/content/MD_RangeDimension.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/content/MD_RangeDimension_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/content/MD_RangeDimension_Type.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.MD_RangeDimension" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/AbstractObject_Type.xml">
+  <g:body>
+
+    <g:element g:targetName="gmd:sequenceIdentifier" minOccurs="0"
+      g:extends="$base/schema/gco/basicTypes/MemberName_PropertyType.xml"/>
+
+    <g:element g:targetName="gmd:descriptor" minOccurs="0"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/AbstractDQ_Completeness.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/AbstractDQ_Completeness.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:abstract="true"
+           g:extends="$base/schema/gmd/dataQuality/AbstractDQ_Completness_Type.xml">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/AbstractDQ_Completeness_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/AbstractDQ_Completeness_Type.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gmd/dataQuality/AbstractDQ_Element_Type.xml" g:abstract="true">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/AbstractDQ_Element.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/AbstractDQ_Element.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:abstract="true"
+           g:extends="$base/schema/gmd/dataQuality/AbstractDQ_Element_Type.xml">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/AbstractDQ_Element_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/AbstractDQ_Element_Type.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.AbstractDQ_Element" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/AbstractObject_Type.xml" g:abstract="true">
+  <g:body>
+
+    <g:element g:targetName="gmd:nameOfMeasure" g:minOccurs="0" g:maxOccurs="unbounded"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml">
+    </g:element>
+
+    <g:element g:targetName="gmd:dateTime" g:minOccurs="0" g:maxOccurs="unbounded"
+      g:extends="$base/schema/gco/basicTypes/DateTime_PropertyType.xml">
+    </g:element>
+
+    <g:tabs g:extends="$base/core/ui/Tabs.xml">
+      <g:body>
+        <g:element g:targetName="gmd:measureIdentification" g:minOccurs="0"
+          g:extends="$base/schema/gmd/referenceSystem/MD_Identifier_PropertyType.xml">
+        </g:element>
+
+        <g:element g:targetName="gmd:measureDescription" g:minOccurs="0"
+          g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml">
+        </g:element>
+
+        <g:element g:targetName="gmd:evaluationMethodType" g:minOccurs="0"
+          g:extends="$base/schema/gmd/dataQuality/DQ_EvaluationMethodTypeCode_PropertyType.xml">
+        </g:element>
+
+        <g:element g:targetName="gmd:evaluationMethodDescription" g:minOccurs="0"
+          g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml">
+        </g:element>
+
+        <g:element g:targetName="gmd:evaluationProcedure" g:minOccurs="0"
+          g:extends="$base/schema/gmd/citation/CI_Citation_PropertyType.xml">
+        </g:element>
+      </g:body>
+    </g:tabs>
+
+    <g:tabs g:extends="$base/core/ui/Tabs.xml">
+      <g:body>
+        <g:element g:targetName="gmd:result" g:minOccurs="0"
+          g:extends="$base/schema/gmd/dataQuality/DQ_ConformanceResult_PropertyType.xml">
+        </g:element>
+
+        <g:element g:targetName="gmd:result" g:minOccurs="0"
+          g:extends="$base/schema/gmd/dataQuality/DQ_QuantitativeResult_PropertyType.xml">
+        </g:element>
+      </g:body>
+    </g:tabs>
+
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/AbstractDQ_LogicalConsistency.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/AbstractDQ_LogicalConsistency.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:abstract="true"
+           g:extends="$base/schema/gmd/dataQuality/AbstractDQ_LogicalConsistency_Type.xml">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/AbstractDQ_LogicalConsistency_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/AbstractDQ_LogicalConsistency_Type.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gmd/dataQuality/AbstractDQ_Element_Type.xml" g:abstract="true">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/AbstractDQ_PositionalAccuracy.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/AbstractDQ_PositionalAccuracy.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:abstract="true"
+           g:extends="$base/schema/gmd/dataQuality/AbstractDQ_PositionalAccuracy_Type.xml">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/AbstractDQ_PositionalAccuracy_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/AbstractDQ_PositionalAccuracy_Type.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gmd/dataQuality/AbstractDQ_Element_Type.xml" g:abstract="true">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/AbstractDQ_Result.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/AbstractDQ_Result.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:abstract="true"
+           g:extends="$base/schema/gmd/dataQuality/AbstractDQ_Result_Type.xml">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/AbstractDQ_Result_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/AbstractDQ_Result_Type.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/AbstractObject_Type.xml" g:abstract="true">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/AbstractDQ_TemporalAccuracy.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/AbstractDQ_TemporalAccuracy.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:abstract="true"
+           g:extends="$base/schema/gmd/dataQuality/AbstractDQ_Completeness_Type.xml">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/AbstractDQ_TemporalAccuracy_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/AbstractDQ_TemporalAccuracy_Type.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gmd/dataQuality/AbstractDQ_Element_Type.xml" g:abstract="true">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/AbstractDQ_ThematicAccuracy.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/AbstractDQ_ThematicAccuracy.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:abstract="true"
+           g:extends="$base/schema/gmd/dataQuality/AbstractDQ_ThematicAccuracy_Type.xml">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/AbstractDQ_ThematicAccuracy_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/AbstractDQ_ThematicAccuracy_Type.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gmd/dataQuality/AbstractDQ_Element_Type.xml" g:abstract="true">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_AbsoluteExternalPositionalAccuracy.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_AbsoluteExternalPositionalAccuracy.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:DQ_AbsoluteExternalPositionalAccuracy"
+           g:extends="$base/schema/gmd/dataQuality/DQ_AbsoluteExternalPositionalAccuracy_Type.xml">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_AbsoluteExternalPositionalAccuracy_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_AbsoluteExternalPositionalAccuracy_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="DQ_AbsoluteExternalPositionalAccuracy" 
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">
+  <g:body>
+    <g:import g:minOccurs="0" g:src="$base/schema/gmd/dataQuality/DQ_AbsoluteExternalPositionalAccuracy.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_AbsoluteExternalPositionalAccuracy_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_AbsoluteExternalPositionalAccuracy_Type.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:label="$i18n.catalog.iso19139.DQ_AbsoluteExternalPositionalAccuracy"
+           g:extends="$base/schema/gmd/dataQuality/AbstractDQ_PositionalAccuracy_Type.xml">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_AccuracyOfATimeMeasurement.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_AccuracyOfATimeMeasurement.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:DQ_AccuracyOfATimeMeasurement"
+           g:extends="$base/schema/gmd/dataQuality/DQ_AccuracyOfATimeMeasurement_Type.xml">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_AccuracyOfATimeMeasurement_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_AccuracyOfATimeMeasurement_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="DQ_AccuracyOfATimeMeasurement"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">
+  <g:body>
+    <g:import g:minOccurs="0" g:src="$base/schema/gmd/dataQuality/DQ_AccuracyOfATimeMeasurement.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_AccuracyOfATimeMeasurement_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_AccuracyOfATimeMeasurement_Type.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:label="$i18n.catalog.iso19139.DQ_AccuracyOfATimeMeasurement"
+           g:extends="$base/schema/gmd/dataQuality/AbstractDQ_TemporalAccuracy_Type.xml">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_CompletenessCommission.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_CompletenessCommission.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:DQ_CompletenessCommission"
+           g:extends="$base/schema/gmd/dataQuality/DQ_CompletenessCommission_Type.xml">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_CompletenessCommission_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_CompletenessCommission_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="DQ_CompletenessCommission"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">
+  <g:body>
+    <g:import g:minOccurs="0" g:src="$base/schema/gmd/dataQuality/DQ_CompletenessCommission.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_CompletenessCommission_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_CompletenessCommission_Type.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:label="$i18n.catalog.iso19139.DQ_CompletenessCommission"
+           g:extends="$base/schema/gmd/dataQuality/AbstractDQ_Completeness_Type.xml">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_CompletenessOmission.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_CompletenessOmission.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:DQ_CompletenessOmmission"
+           g:extends="$base/schema/gmd/dataQuality/DQ_CompletenessOmission_Type.xml">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_CompletenessOmission_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_CompletenessOmission_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="DQ_CompletenessOmission"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">
+  <g:body>
+    <g:import g:minOccurs="0" g:src="$base/schema/gmd/dataQuality/DQ_CompletenessOmission.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_CompletenessOmission_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_CompletenessOmission_Type.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:label="$i18n.catalog.iso19139.DQ_CompletenessOmission"
+           g:extends="$base/schema/gmd/dataQuality/AbstractDQ_Completeness_Type.xml">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_Completeness_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_Completeness_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gmd/dataQuality/AbstractDQ_Completeness.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_ConceptualConsistency.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_ConceptualConsistency.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:DQ_ConceptualConsistency"
+           g:extends="$base/schema/gmd/dataQuality/DQ_ConceptualConsistency_Type.xml">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_ConceptualConsistency_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_ConceptualConsistency_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="DQ_ConceptualConsistency"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">
+  <g:body>
+    <g:import g:minOccurs="0" g:src="$base/schema/gmd/dataQuality/DQ_ConceptualConsistency.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_ConceptualConsistency_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_ConceptualConsistency_Type.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:label="$i18n.catalog.iso19139.DQ_ConceptualConsistency"
+           g:extends="$base/schema/gmd/dataQuality/AbstractDQ_LogicalConsistency_Type.xml">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_ConformanceResult.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_ConformanceResult.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:DQ_ConformanceResult"
+           g:extends="$base/schema/gmd/dataQuality/DQ_ConformanceResult_Type.xml">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_ConformanceResult_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_ConformanceResult_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:label="$i18n.catalog.iso19139.DQ_ConformanceResult"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gmd/dataQuality/DQ_ConformanceResult.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_ConformanceResult_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_ConformanceResult_Type.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.DQ_ConformanceResult" g:label="$i18nBase"
+           g:extends="$base/schema/gmd/dataQuality/AbstractDQ_Result_Type.xml">
+  <g:body>
+
+    <g:element g:targetName="gmd:specification"
+      g:extends="$base/schema/gmd/citation/CI_Citation_PropertyType.xml">
+    </g:element>
+
+    <g:element g:targetName="gmd:explanation"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml">
+    </g:element>
+
+    <g:element g:targetName="gmd:pass"
+      g:extends="$base/schema/gco/basicTypes/Boolean_PropertyType.xml">
+    </g:element>
+
+  </g:body>
+
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_DataQuality.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_DataQuality.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:DQ_DataQuality"
+           g:extends="$base/schema/gmd/dataQuality/DQ_DataQuality_Type.xml">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_DataQuality_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_DataQuality_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gmd/dataQuality/DQ_DataQuality.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_DataQuality_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_DataQuality_Type.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.DQ_DataQuality" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/AbstractObject_Type.xml">
+  <g:body>
+    <g:tabs g:extends="$base/core/ui/Tabs.xml">
+      <g:body>
+
+        <g:element g:targetName="gmd:scope"
+          g:extends="$base/schema/gmd/dataQuality/DQ_Scope_PropertyType.xml">
+        </g:element>
+
+        <g:element g:targetName="gmd:report" g:minOccurs="0" g:maxOccurs="unbounded"
+          g:extends="$base/schema/gmd/dataQuality/DQ_Element_PropertyType.xml">
+        </g:element>
+
+        <g:element g:targetName="gmd:lineage" g:minOccurs="0"
+          g:extends="$base/schema/gmd/dataQuality/LI_Lineage_PropertyType.xml">
+        </g:element>
+
+      </g:body>
+    </g:tabs>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_DomainConsistency.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_DomainConsistency.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:DQ_DomainConsistency"
+           g:extends="$base/schema/gmd/dataQuality/DQ_DomainConsistency_Type.xml">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_DomainConsistency_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_DomainConsistency_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="DQ_DomainConsistency"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">
+  <g:body>
+    <g:import g:minOccurs="0" g:src="$base/schema/gmd/dataQuality/DQ_DomainConsistency.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_DomainConsistency_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_DomainConsistency_Type.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:label="$i18n.catalog.iso19139.DQ_DomainConsistency"
+           g:extends="$base/schema/gmd/dataQuality/AbstractDQ_LogicalConsistency_Type.xml">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_Element_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_Element_PropertyType.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">
+  <g:body>
+    <g:elementChoice g:minOccurs="0" g:extends="$base/xtn/ui/UI_ElementChoice.xml">
+      <g:body>
+	      <g:element g:extends="$base/schema/gmd/dataQuality/DQ_AbsoluteExternalPositionalAccuracy.xml"/>
+          <g:element g:extends="$base/schema/gmd/dataQuality/DQ_AccuracyOfATimeMeasurement.xml"/>
+          <g:element g:extends="$base/schema/gmd/dataQuality/DQ_GriddedDataPositionalAccuracy.xml"/>
+          <g:element g:extends="$base/schema/gmd/dataQuality/DQ_NonQuantitativeAttributeAccuracy.xml"/>
+          <g:element g:extends="$base/schema/gmd/dataQuality/DQ_QuantitativeAttributeAccuracy.xml"/>
+          <g:element g:extends="$base/schema/gmd/dataQuality/DQ_RelativeInternalPositionalAccuracy.xml"/>
+          <g:element g:extends="$base/schema/gmd/dataQuality/DQ_CompletenessCommission.xml"/>
+          <g:element g:extends="$base/schema/gmd/dataQuality/DQ_CompletenessOmission.xml"/>
+          <g:element g:extends="$base/schema/gmd/dataQuality/DQ_ConceptualConsistency.xml"/>
+          <g:element g:extends="$base/schema/gmd/dataQuality/DQ_DomainConsistency.xml"/>
+          <g:element g:extends="$base/schema/gmd/dataQuality/DQ_FormatConsistency.xml"/>
+          <g:element g:extends="$base/schema/gmd/dataQuality/DQ_TopologicalConsistency.xml"/>
+          <g:element g:extends="$base/schema/gmd/dataQuality/DQ_TemporalConsistency.xml"/>
+          <g:element g:extends="$base/schema/gmd/dataQuality/DQ_TemporalValidity.xml"/>
+          <g:element g:extends="$base/schema/gmd/dataQuality/DQ_ThematicClassificationCorrectness.xml"/>
+      </g:body>
+    </g:elementChoice>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_EvaluationMethodTypeCode.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_EvaluationMethodTypeCode.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:DQ_EvaluationMethodTypeCode"
+           g:i18nBase="catalog.iso19139.DQ_EvaluationMethodTypeCode" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/CodeListValue_Type.xml">
+  <g:body>
+
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeSpace.xml"
+      g:value="ISOTC211/19115"/>
+
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeList.xml"
+      g:value="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#DQ_EvaluationMethodTypeCode"/>
+
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeListValue.xml">
+      <g:body>
+        <g:input g:extends="$base/core/ui/InputSelectOne.xml">
+          <g:options>
+            <g:option g:label="" g:value="" />
+            <g:option g:label="$i18nBase.directInternal" g:value="directInternal" />
+            <g:option g:label="$i18nBase.directExternal" g:value="directExternal"/>
+            <g:option g:label="$i18nBase.indirect" g:value="indirect"/>
+          </g:options>
+        </g:input>
+      </g:body>
+    </g:attribute>
+
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_EvaluationMethodTypeCode_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_EvaluationMethodTypeCode_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/xtn/Wrapped_CodePropertyType.xml">
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gmd/constraints/MD_RestrictionCode.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_FormatConsistency.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_FormatConsistency.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:DQ_FormatConsistency"
+           g:extends="$base/schema/gmd/dataQuality/DQ_FormatConsistency_Type.xml">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_FormatConsistency_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_FormatConsistency_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="DQ_FormatConsistency"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">
+  <g:body>
+    <g:import g:minOccurs="0" g:src="$base/schema/gmd/dataQuality/DQ_FormatConsistency.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_FormatConsistency_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_FormatConsistency_Type.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:label="$i18n.catalog.iso19139.DQ_FormatConsistency"
+           g:extends="$base/schema/gmd/dataQuality/AbstractDQ_LogicalConsistency_Type.xml">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_GriddedDataPositionalAccuracy.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_GriddedDataPositionalAccuracy.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:DQ_GriddedDataPositionalAccuracy"
+           g:extends="$base/schema/gmd/dataQuality/DQ_GriddedDataPositionalAccuracy_Type.xml">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_GriddedDataPositionalAccuracy_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_GriddedDataPositionalAccuracy_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="DQ_GriddedDataPositionalAccuracy"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">
+  <g:body>
+    <g:import g:minOccurs="0" g:src="$base/schema/gmd/dataQuality/DQ_GriddedDataPositionalAccuracy.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_GriddedDataPositionalAccuracy_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_GriddedDataPositionalAccuracy_Type.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:label="$i18n.catalog.iso19139.DQ_GriddedDataPositionalAccuracy"
+           g:extends="$base/schema/gmd/dataQuality/AbstractDQ_PositionalAccuracy_Type.xml">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_LogicalConsistency_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_LogicalConsistency_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gmd/dataQuality/AbstractDQ_LogicalConsistency.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_NonQuantitativeAttributeAccuracy.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_NonQuantitativeAttributeAccuracy.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:DQ_NonQuantitativeAttributeAccuracy"
+           g:extends="$base/schema/gmd/dataQuality/DQ_NonQuantitativeAttributeAccuracy_Type.xml">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_NonQuantitativeAttributeAccuracy_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_NonQuantitativeAttributeAccuracy_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="DQ_NonQuantitativeAttributeAccuracy"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">
+  <g:body>
+    <g:import g:minOccurs="0" g:src="$base/schema/gmd/dataQuality/DQ_NonQuantitativeAttributeAccuracy.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_NonQuantitativeAttributeAccuracy_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_NonQuantitativeAttributeAccuracy_Type.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:label="$i18n.catalog.iso19139.DQ_NonQuantitiveAttributeAccuracy"
+           g:extends="$base/schema/gmd/dataQuality/AbstractDQ_ThematicAccuracy_Type.xml">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_PositionalAccuracy_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_PositionalAccuracy_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gmd/dataQuality/AbstractDQ_PositionalAccuracy.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_QuantitativeAttributeAccuracy.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_QuantitativeAttributeAccuracy.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:DQ_QuantitativeAttributeAccuracy"
+           g:extends="$base/schema/gmd/dataQuality/DQ_QuantitativeAttributeAccuracy_Type.xml">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_QuantitativeAttributeAccuracy_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_QuantitativeAttributeAccuracy_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="DQ_QuantitativeAttributeAccuracy"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">
+  <g:body>
+    <g:import g:minOccurs="0" g:src="$base/schema/gmd/dataQuality/DQ_QuantitativeAttributeAccuracy.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_QuantitativeAttributeAccuracy_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_QuantitativeAttributeAccuracy_Type.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:label="$i18n.catalog.iso19139.DQ_QuantitativeAttributeAccuracy"
+           g:extends="$base/schema/gmd/dataQuality/AbstractDQ_ThematicAccuracy_Type.xml">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_QuantitativeResult.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_QuantitativeResult.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:DQ_QuantitativeResult"
+           g:extends="$base/schema/gmd/dataQuality/DQ_QuantitativeResult_Type.xml">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_QuantitativeResult_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_QuantitativeResult_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:label="$i18n.catalog.iso19139.DQ_QuantitativeResult"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gmd/dataQuality/DQ_QuantitativeResult.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_QuantitativeResult_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_QuantitativeResult_Type.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.DQ_QuantitativeResult" g:label="$i18nBase"
+           g:extends="$base/schema/gmd/dataQuality/AbstractDQ_Result_Type.xml">
+  <g:body>
+
+    <g:element g:targetName="gmd:valueType" g:minOccurs="0"
+      g:extends="$base/schema/gco/basicTypes/RecordType_PropertyType.xml">
+    </g:element>
+
+    <!-- TODO properly define UnitDefinition int UnitOfMeasure_PropertyType
+    <g:element g:targetName="gmd:valueUnit"
+      g:extends="$base/schema/gco/basicTypes/UnitOfMeasure_PropertyType.xml">
+    </g:element>
+    -->
+
+    <g:element g:targetName="gmd:errorStatistic" g:minOccurs="0"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml">
+    </g:element>
+
+    <g:element g:targetName="gmd:value" g:maxOccurs="unbounded"
+      g:extends="$base/schema/gco/basicTypes/Record_PropertyType.xml">
+    </g:element>
+
+  </g:body>
+  
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_RelativeInternalPositionalAccuracy.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_RelativeInternalPositionalAccuracy.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:DQ_RelativeInternalPositionalAccuracy"
+           g:extends="$base/schema/gmd/dataQuality/DQ_RelativeInternalPositionalAccuracy_Type.xml">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_RelativeInternalPositionalAccuracy_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_RelativeInternalPositionalAccuracy_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="DQ_RelativeInternalPositionalAccuracy"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">
+  <g:body>
+    <g:import g:minOccurs="0" g:src="$base/schema/gmd/dataQuality/DQ_RelativeInternalPositionalAccuracy.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_RelativeInternalPositionalAccuracy_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_RelativeInternalPositionalAccuracy_Type.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:label="$i18n.catalog.iso19139.DQ_RelativeInternalPositionalAccuracy"
+           g:extends="$base/schema/gmd/dataQuality/AbstractDQ_PositionalAccuracy_Type.xml">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_Result_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_Result_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gmd/dataQuality/AbstractDQ_Result.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_Scope.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_Scope.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:DQ_Scope"
+           g:extends="$base/schema/gmd/dataQuality/DQ_Scope_Type.xml">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_Scope_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_Scope_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gmd/dataQuality/DQ_Scope.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_Scope_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_Scope_Type.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.DQ_Scope" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/AbstractObject_Type.xml">
+  <g:body>
+    <g:tabs g:extends="$base/core/ui/Tabs.xml">
+      <g:body>
+        <g:element g:targetName="gmd:level"
+          g:extends="$base/schema/gmd/maintenance/MD_ScopeCode_PropertyType.xml">
+        </g:element>
+
+        <g:element g:targetName="gmd:extent" g:minOccurs="0"
+          g:extends="$base/schema/gmd/extent/EX_Extent_PropertyType.xml">
+        </g:element>
+
+        <g:element g:targetName="gmd:levelDescription" g:minOccurs="0" g:maxOccurs="unbounded"
+          g:extends="$base/schema/gmd/maintenance/MD_ScopeDescription_PropertyType.xml">
+        </g:element>
+      </g:body>
+    </g:tabs>
+
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_TemporalAccuracy_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_TemporalAccuracy_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gmd/dataQuality/AbstractDQ_TemporalAccuracy.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_TemporalConsistency.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_TemporalConsistency.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:DQ_TemporalConsistency"
+           g:extends="$base/schema/gmd/dataQuality/DQ_TemporalConsistency_Type.xml">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_TemporalConsistency_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_TemporalConsistency_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="DQ_TemporalConsistency"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">
+  <g:body>
+    <g:import g:minOccurs="0" g:src="$base/schema/gmd/dataQuality/DQ_TemporalConsistency.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_TemporalConsistency_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_TemporalConsistency_Type.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:label="$i18n.catalog.iso19139.DQ_TemporalConsistency"
+           g:extends="$base/schema/gmd/dataQuality/AbstractDQ_TemporalAccuracy_Type.xml">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_TemporalValidity.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_TemporalValidity.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:DQ_TemporalValidity"
+           g:extends="$base/schema/gmd/dataQuality/DQ_TemporalValidity_Type.xml">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_TemporalValidity_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_TemporalValidity_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="DQ_TemporalValidity"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">
+  <g:body>
+    <g:import g:minOccurs="0" g:src="$base/schema/gmd/dataQuality/DQ_TemporalValidity.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_TemporalValidity_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_TemporalValidity_Type.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:label="$i18n.catalog.iso19139.DQ_TemporalValidity"
+           g:extends="$base/schema/gmd/dataQuality/AbstractDQ_TemporalAccuracy_Type.xml">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_ThematicAccuracy_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_ThematicAccuracy_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gmd/dataQuality/AbstractDQ_ThematicAccuracy.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_ThematicClassificationCorrectness.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_ThematicClassificationCorrectness.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:DQ_ThematicClassificationCorrectness"
+           g:extends="$base/schema/gmd/dataQuality/DQ_ThematicClassificationCorrectness_Type.xml">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_ThematicClassificationCorrectness_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_ThematicClassificationCorrectness_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="DQ_ThematicClassificationCorrectness"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">
+  <g:body>
+    <g:import g:minOccurs="0" g:src="$base/schema/gmd/dataQuality/DQ_ThematicClassificationCorrectness.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_ThematicClassificationCorrectness_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_ThematicClassificationCorrectness_Type.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:label="$i18n.catalog.iso19139.DQ_ThematicClassificationCorrectness"
+           g:extends="$base/schema/gmd/dataQuality/AbstractDQ_ThematicAccuracy_Type.xml">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_TopologicalConsistency.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_TopologicalConsistency.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:DQ_TopologicalConsistency"
+           g:extends="$base/schema/gmd/dataQuality/DQ_TopologicalConsistency_Type.xml">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_TopologicalConsistency_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_TopologicalConsistency_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="DQ_TopologicalConsistency"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">
+  <g:body>
+    <g:import g:minOccurs="0" g:src="$base/schema/gmd/dataQuality/DQ_TopologicalConsistency.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_TopologicalConsistency_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/DQ_TopologicalConsistency_Type.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:label="$i18n.catalog.iso19139.DQ_TopologicalConsistency"
+           g:extends="$base/schema/gmd/dataQuality/AbstractDQ_LogicalConsistency_Type.xml">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/LI_Lineage.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/LI_Lineage.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:LI_Lineage"
+           g:extends="$base/schema/gmd/dataQuality/LI_Lineage_Type.xml">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/LI_Lineage_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/LI_Lineage_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gmd/dataQuality/LI_Lineage.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/LI_Lineage_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/LI_Lineage_Type.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.LI_Lineage" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/AbstractObject_Type.xml">
+  <g:body>
+
+    <g:tabs g:extends="$base/core/ui/Tabs.xml">
+      <g:body>
+        <g:element g:targetName="gmd:statement" minOccurs="0"
+          g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml">
+        </g:element>
+
+        <g:element g:targetName="gmd:processStep" minOccurs="0" maxOccurs="unbounded"
+          g:extends="$base/schema/gmd/dataQuality/LI_ProcessStep_PropertyType.xml">
+        </g:element>
+
+        <g:element g:targetName="gmd:source" minOccurs="0" maxOccurs="unbounded"
+          g:extends="$base/schema/gmd/dataQuality/LI_Source_PropertyType.xml">
+        </g:element>
+      </g:body>
+    </g:tabs>
+
+  </g:body>
+
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/LI_ProcessStep.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/LI_ProcessStep.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:LI_ProcessStep"
+           g:extends="$base/schema/gmd/dataQuality/LI_ProcessStep_Type.xml">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/LI_ProcessStep_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/LI_ProcessStep_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gmd/dataQuality/LI_ProcessStep.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/LI_ProcessStep_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/LI_ProcessStep_Type.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.LI_ProcessStep" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/AbstractObject_Type.xml">
+  <g:body>
+
+    <g:element g:targetName="gmd:description"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml">
+    </g:element>
+
+    <g:element g:targetName="gmd:dateTime" minOccurs="0"
+      g:extends="$base/schema/gco/basicTypes/DateTime_PropertyType.xml">
+    </g:element>
+
+    <g:tabs g:extends="$base/core/ui/Tabs.xml">
+      <g:body>
+        <g:element g:targetName="gmd:rationale" minOccurs="0"
+          g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml">
+        </g:element>
+
+        <g:element g:targetName="gmd:processor" minOccurs="0" maxOccurs="unbounded"
+          g:extends="$base/schema/gmd/citation/CI_ResponsibleParty_PropertyType.xml">
+        </g:element>
+
+        <!-- TODO (possible recurrection) -->
+        <g:element g:targetName="gmd:source" minOccurs="0" maxOccurs="unbounded"
+          g:extends="$base/schema/gmd/dataQuality/LI_Source_PropertyType.xml">
+        </g:element>
+      </g:body>
+    </g:tabs>
+
+  </g:body>
+
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/LI_Source.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/LI_Source.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:LI_Source"
+           g:extends="$base/schema/gmd/dataQuality/LI_Source_Type.xml">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/LI_Source_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/LI_Source_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gmd/dataQuality/LI_Source.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/LI_Source_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/dataQuality/LI_Source_Type.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.LI_Source" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/AbstractObject_Type.xml">
+  <g:body>
+
+    <g:element g:targetName="gmd:description" minOccurs="0"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml">
+    </g:element>
+
+    <g:tabs g:extends="$base/core/ui/Tabs.xml">
+      <g:body>
+        <g:element g:targetName="gmd:scaleDenominator" minOccurs="0"
+          g:extends="$base/schema/gmd/identification/MD_RepresentativeFraction_PropertyType.xml">
+        </g:element>
+
+        <g:element g:targetName="gmd:sourceReferenceSystem" minOccurs="0"
+          g:extends="$base/schema/gmd/referenceSystem/MD_ReferenceSystem_PropertyType.xml">
+        </g:element>
+
+        <g:element g:targetName="gmd:sourceCitation" minOccurs="0"
+          g:extends="$base/schema/gmd/citation/CI_Citation_PropertyType.xml">
+        </g:element>
+
+        <g:element g:targetName="gmd:sourceExtent" minOccurs="0" maxOccurs="unbounded"
+          g:extends="$base/schema/gmd/extent/EX_Extent_PropertyType.xml">
+        </g:element>
+
+        <!-- TODO (recurrent)
+        <g:element g:targetName="gmd:sourceStep" minOccurs="0" maxOccurs="unbounded"
+          g:extends="$base/schema/gmd/dataQuality/LI_ProcessStep_PropertyType.xml">
+        </g:element>
+        -->
+      </g:body>
+    </g:tabs>
+
+  </g:body>
+
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/distribution/MD_DigitalTransferOptions.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/distribution/MD_DigitalTransferOptions.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_DigitalTransferOptions" 
+           g:extends="$base/schema/gmd/distribution/MD_DigitalTransferOptions_Type.xml"/> 

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/distribution/MD_DigitalTransferOptions_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/distribution/MD_DigitalTransferOptions_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" 
+      g:extends="$base/schema/gmd/distribution/MD_DigitalTransferOptions.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/distribution/MD_DigitalTransferOptions_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/distribution/MD_DigitalTransferOptions_Type.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.MD_DigitalTransferOptions" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/AbstractObject_Type.xml">
+  <g:annotation>
+    <g:documentation>Technical means and media by which a dataset is obtained from the distributor</g:documentation>
+  </g:annotation>
+  <g:body>
+  
+    <g:element g:targetName="gmd:unitsOfDistribution" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+      
+    <g:element g:targetName="gmd:transferSize" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/Real_PropertyType.xml"/>
+      
+    <g:element g:targetName="gmd:onLine" g:minOccurs="0" g:maxOccurs="unbounded"
+      g:extends="$base/schema/gmd/citation/CI_OnlineResource_PropertyType.xml"/>
+      
+    <g:element g:targetName="gmd:offLine" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gmd/distribution/MD_Medium_PropertyType.xml"/>
+    
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/distribution/MD_Distribution.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/distribution/MD_Distribution.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_Distribution" 
+           g:extends="$base/schema/gmd/distribution/MD_Distribution_Type.xml"/> 

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/distribution/MD_DistributionUnits.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/distribution/MD_DistributionUnits.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_DistributionUnits" 
+           g:i18nBase="catalog.iso19139.MD_DistributionUnits" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/CodeListValue_Type.xml">
+  <g:body>
+   
+    <!--  TODO codespace and codelist -->
+    
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeSpace.xml" 
+      g:value=""/>
+       
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeList.xml"
+      g:value=""/>
+     
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeListValue.xml">
+      <g:body>
+        <g:input g:extends="$base/core/ui/InputSelectOne.xml">
+          <g:options>
+            <g:option g:label="" g:value=""/>
+            <g:option g:label="$i18nBase." g:value=""/>
+          </g:options>
+        </g:input>
+      </g:body>          
+    </g:attribute>     
+     
+  </g:body> 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/distribution/MD_DistributionUnits_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/distribution/MD_DistributionUnits_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/xtn/Wrapped_CodePropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" 
+      g:extends="$base/schema/gmd/distribution/MD_DistributionUnits.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/distribution/MD_Distribution_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/distribution/MD_Distribution_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" 
+      g:extends="$base/schema/gmd/distribution/MD_Distribution.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/distribution/MD_Distribution_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/distribution/MD_Distribution_Type.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.MD_Distribution" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/AbstractObject_Type.xml">
+  <g:annotation>
+    <g:documentation>Information about the distributor of and options for obtaining the dataset</g:documentation>
+  </g:annotation>
+  <g:body>
+    
+    <!-- MODIFIED - the container below mirrors the original XSD structure -->
+    <g:container g:rendered="$editor.isOriginalMode">
+    
+	    <g:tabs g:extends="$base/xtn/ui/UI_Tabs.xml">
+	      <g:body>
+	  
+	        <g:element g:targetName="gmd:distributionFormat" g:minOccurs="0" g:maxOccurs="unbounded"
+	          g:extends="$base/schema/gmd/distribution/MD_Format_PropertyType.xml"/>
+	          
+	        <g:element g:targetName="gmd:distributor" g:minOccurs="0" g:maxOccurs="unbounded"
+	          g:extends="$base/schema/gmd/distribution/MD_Distributor_PropertyType.xml"/>
+	          
+	        <g:element g:targetName="gmd:transferOptions" g:minOccurs="0" g:maxOccurs="unbounded"
+	          g:extends="$base/schema/gmd/distribution/MD_DigitalTransferOptions_PropertyType.xml"/>
+	
+	      </g:body>
+	    </g:tabs>
+      
+    </g:container>
+    
+    <!-- MODIFIED - the container below produces a simplified structure -->
+    <g:container g:rendered="$editor.isSimplifiedMode">
+    
+	    <g:element g:targetName="gmd:distributionFormat" g:minOccurs="0" g:maxOccurs="unbounded"
+	      g:extends="$base/xtn/ui/UI_Element.xml">
+	      <g:body>
+	        <g:element g:targetName="gmd:MD_Format" g:minOccurs="0" g:maxOccurs="1"
+	          g:i18nBase="catalog.iso19139.MD_Format"
+	          h:tag="div" g:jsClass="gxe.control.Element"> 
+	          
+				    <g:element g:targetName="gmd:name" g:minOccurs="1" g:maxOccurs="1"
+				      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+              
+				    <g:element g:targetName="gmd:version" g:minOccurs="1" g:maxOccurs="1"
+				      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+	              
+	        </g:element>
+	      </g:body>
+	    </g:element>
+                
+      <g:element g:targetName="gmd:transferOptions" g:minOccurs="0" g:maxOccurs="1"
+        h:tag="div" g:jsClass="gxe.control.Element">
+        <g:element g:targetName="gmd:MD_DigitalTransferOptions" g:minOccurs="0" g:maxOccurs="1"
+          h:tag="div" g:jsClass="gxe.control.Element"
+          g:i18nBase="catalog.iso19139.MD_DigitalTransferOptions"> 
+          <g:element g:targetName="gmd:onLine" g:minOccurs="0" g:maxOccurs="unbounded"
+            g:extends="$base/xtn/ui/UI_Element.xml">
+            <g:body>
+            
+	            <g:element g:targetName="gmd:CI_OnlineResource" g:minOccurs="0" g:maxOccurs="1"
+	              g:i18nBase="catalog.iso19139.CI_OnlineResource"
+	              h:tag="div" g:jsClass="gxe.control.Element"> 
+              
+	              <g:element g:targetName="gmd:linkage" g:minOccurs="1" g:maxOccurs="1"
+	                g:extends="$base/schema/gmd/citation/URL_PropertyType.xml"/>
+	                
+						    <g:element g:targetName="gmd:function" g:minOccurs="0" g:maxOccurs="1"
+						      g:extends="$base/schema/gmd/citation/CI_OnLineFunctionCode_PropertyType.xml"/>
+							      
+	            </g:element>
+            </g:body>
+          </g:element>
+        </g:element>
+      </g:element> 
+         
+    </g:container>
+        
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/distribution/MD_Distributor.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/distribution/MD_Distributor.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_Distributor" 
+           g:extends="$base/schema/gmd/distribution/MD_Distributor_Type.xml"/> 

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/distribution/MD_Distributor_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/distribution/MD_Distributor_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" 
+      g:extends="$base/schema/gmd/distribution/MD_Distributor.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/distribution/MD_Distributor_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/distribution/MD_Distributor_Type.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.MD_Distributor" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/AbstractObject_Type.xml">
+  <g:annotation>
+    <g:documentation>Information about the distributor</g:documentation>
+  </g:annotation>
+  <g:body>
+  
+    <g:tabs g:extends="$base/xtn/ui/UI_Tabs.xml">
+      <g:body>
+      
+		    <g:element g:targetName="gmd:distributorContact" g:minOccurs="1" g:maxOccurs="1"
+		      g:extends="$base/schema/gmd/citation/CI_ResponsibleParty_PropertyType.xml"/>
+		      
+		    <g:element g:targetName="gmd:distributionOrderProcess" g:minOccurs="0" g:maxOccurs="unbounded"
+		      g:extends="$base/schema/gmd/distribution/MD_StandardOrderProcess_PropertyType.xml"/>
+		      
+		    <g:element g:targetName="gmd:distributorFormat" g:minOccurs="0" g:maxOccurs="unbounded"
+		      g:extends="$base/schema/gmd/distribution/MD_Format_PropertyType.xml"/>
+		
+		    <g:element g:targetName="gmd:distributorTransferOptions" g:minOccurs="0" g:maxOccurs="unbounded"
+		      g:extends="$base/schema/gmd/distribution/MD_DigitalTransferOptions_PropertyType.xml"/>
+
+      </g:body>
+    </g:tabs>
+        
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/distribution/MD_Format.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/distribution/MD_Format.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_Format" 
+           g:extends="$base/schema/gmd/distribution/MD_Format_Type.xml"/> 

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/distribution/MD_Format_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/distribution/MD_Format_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" 
+      g:extends="$base/schema/gmd/distribution/MD_Format.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/distribution/MD_Format_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/distribution/MD_Format_Type.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.MD_Format" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/AbstractObject_Type.xml">
+  <g:annotation>
+    <g:documentation>Description of the form of the data to be distributed</g:documentation>
+  </g:annotation>
+  <g:body>
+  
+    <g:element g:targetName="gmd:name" g:minOccurs="1" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+      
+    <g:element g:targetName="gmd:version" g:minOccurs="1" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+      
+    <g:element g:targetName="gmd:amendmentNumber" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+      
+    <g:element g:targetName="gmd:specification" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+      
+    <g:element g:targetName="gmd:fileDecompressionTechnique" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+      
+    <g:element g:targetName="gmd:formatDistributor" g:minOccurs="0" g:maxOccurs="unbounded"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+    
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/distribution/MD_Medium.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/distribution/MD_Medium.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_Medium" 
+           g:extends="$base/schema/gmd/distribution/MD_Medium_Type.xml"/> 

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/distribution/MD_MediumFormatCode.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/distribution/MD_MediumFormatCode.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_MediumFormatCode" 
+           g:i18nBase="catalog.iso19139.MD_MediumFormatCode" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/CodeListValue_Type.xml">
+  <g:body>
+   
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeSpace.xml" 
+      g:value="ISOTC211/19115"/>
+       
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeList.xml"
+      g:value="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_MediumFormatCode"/>
+     
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeListValue.xml">
+      <g:body>
+        <g:input g:extends="$base/core/ui/InputSelectOne.xml">
+          <g:options>
+            <g:option g:label="" g:value=""/>
+            <g:option g:label="$i18nBase.cpio" g:value="cpio"/>
+            <g:option g:label="$i18nBase.tar" g:value="tar"/>
+            <g:option g:label="$i18nBase.highSierra" g:value="highSierra"/>
+            <g:option g:label="$i18nBase.iso9660" g:value="iso9660"/>
+            <g:option g:label="$i18nBase.iso9660RockRidge" g:value="iso9660RockRidge"/>
+            <g:option g:label="$i18nBase.iso9660AppleHFS" g:value="iso9660AppleHFS"/>
+          </g:options>
+        </g:input>
+      </g:body>          
+    </g:attribute>     
+     
+  </g:body> 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/distribution/MD_MediumFormatCode_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/distribution/MD_MediumFormatCode_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/xtn/Wrapped_CodePropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" 
+      g:extends="$base/schema/gmd/distribution/MD_MediumFormatCode.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/distribution/MD_MediumNameCode.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/distribution/MD_MediumNameCode.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_MediumNameCode" 
+           g:i18nBase="catalog.iso19139.MD_MediumNameCode" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/CodeListValue_Type.xml">
+  <g:body>
+   
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeSpace.xml" 
+      g:value="ISOTC211/19115"/>
+       
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeList.xml"
+      g:value="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_MediumNameCode"/>
+     
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeListValue.xml">
+      <g:body>
+        <g:input g:extends="$base/core/ui/InputSelectOne.xml">
+          <g:options>
+            <g:option g:label="" g:value=""/>
+            <g:option g:label="$i18nBase.cdRom" g:value="cdRom"/>
+            <g:option g:label="$i18nBase.dvd" g:value="dvd"/>
+            <g:option g:label="$i18nBase.3halfInchFloppy" g:value="3halfInchFloppy"/>
+            <g:option g:label="$i18nBase.5quarterInchFloppy" g:value="5quarterInchFloppy"/>
+            <g:option g:label="$i18nBase.7trackTape" g:value="7trackTape"/>
+            <g:option g:label="$i18nBase.9trackType" g:value="9trackType"/>
+            <g:option g:label="$i18nBase.3480Cartridge" g:value="3480Cartridge"/>
+            <g:option g:label="$i18nBase.3490Cartridge" g:value="3490Cartridge"/>
+            <g:option g:label="$i18nBase.3580Cartridge" g:value="3580Cartridge"/>
+            <g:option g:label="$i18nBase.4mmCartridgeTape" g:value="4mmCartridgeTape"/>
+            <g:option g:label="$i18nBase.8mmCartridgeTape" g:value="8mmCartridgeTape"/>
+            <g:option g:label="$i18nBase.1quarterInchCartridgeTape" g:value="1quarterInchCartridgeTape"/>
+            <g:option g:label="$i18nBase.digitalLinearTape" g:value="digitalLinearTape"/>
+            <g:option g:label="$i18nBase.onLine" g:value="onLine"/>
+            <g:option g:label="$i18nBase.satellite" g:value="satellite"/>
+            <g:option g:label="$i18nBase.telephoneLink" g:value="telephoneLink"/>
+            <g:option g:label="$i18nBase.hardcopy" g:value="hardcopy"/>
+          </g:options>
+        </g:input>
+      </g:body>          
+    </g:attribute>     
+     
+  </g:body> 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/distribution/MD_MediumNameCode_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/distribution/MD_MediumNameCode_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/xtn/Wrapped_CodePropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" 
+      g:extends="$base/schema/gmd/distribution/MD_MediumNameCode.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/distribution/MD_Medium_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/distribution/MD_Medium_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" 
+      g:extends="$base/schema/gmd/distribution/MD_Medium.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/distribution/MD_Medium_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/distribution/MD_Medium_Type.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.MD_Medium" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/AbstractObject_Type.xml">
+  <g:annotation>
+    <g:documentation>Information about the media on which the data can be distributed</g:documentation>
+  </g:annotation>
+  <g:body>
+  
+    <g:element g:targetName="gmd:name" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gmd/distribution/MD_MediumNameCode_PropertyType.xml"/>
+      
+    <g:element g:targetName="gmd:density" g:minOccurs="0" g:maxOccurs="unbounded"
+      g:extends="$base/schema/gco/basicTypes/Real_PropertyType.xml"/>
+      
+    <g:element g:targetName="gmd:densityUnits" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+      
+    <g:element g:targetName="gmd:volumes" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/Integer_PropertyType.xml"/>
+      
+    <g:element g:targetName="gmd:mediumFormat" g:minOccurs="0" g:maxOccurs="unbounded"
+      g:extends="$base/schema/gmd/distribution/MD_MediumFormatCode_PropertyType.xml"/>
+      
+    <g:element g:targetName="gmd:mediumNote" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+    
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/distribution/MD_StandardOrderProcess.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/distribution/MD_StandardOrderProcess.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_StandardOrderProcess" 
+           g:extends="$base/schema/gmd/distribution/MD_StandardOrderProcess_Type.xml"/> 

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/distribution/MD_StandardOrderProcess_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/distribution/MD_StandardOrderProcess_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" 
+      g:extends="$base/schema/gmd/distribution/MD_StandardOrderProcess.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/distribution/MD_StandardOrderProcess_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/distribution/MD_StandardOrderProcess_Type.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.MD_StandardOrderProcess" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/AbstractObject_Type.xml">
+  <g:annotation>
+    <g:documentation>Common ways in which the dataset may be obtained or received, and related instructions and fee information</g:documentation>
+  </g:annotation>
+  <g:body>
+  
+    <g:element g:targetName="gmd:fees" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+      
+    <g:element g:targetName="gmd:plannedAvailableDateTime" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/DateTime_PropertyType.xml"/>
+      
+    <g:element g:targetName="gmd:orderingInstructions" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+      
+    <g:element g:targetName="gmd:turnaround" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+    
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/extent/AbstractEX_GeographicExtent.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/extent/AbstractEX_GeographicExtent.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:AbstractEX_GeographicExtent"
+           g:abstract="true"
+           g:extends="$base/schema/gmd/extent/AbstractEX_GeographicExtent_Type.xml">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/extent/AbstractEX_GeographicExtent_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/extent/AbstractEX_GeographicExtent_Type.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.AbstractEX_GeographicExtent" g:label="$i18nBase"
+           g:abstract="true"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">
+  <g:body>
+
+    <g:element g:targetName="gmd:extentTypeCode" minOccurs="0"
+      g:extends="$base/schema/gco/basicTypes/Boolean_PropertyType.xml">
+    </g:element>
+    
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/extent/EX_Extent.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/extent/EX_Extent.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:EX_Extent"
+           g:extends="$base/schema/gmd/extent/EX_Extent_Type.xml">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/extent/EX_Extent_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/extent/EX_Extent_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gmd/extent/EX_Extent.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/extent/EX_Extent_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/extent/EX_Extent_Type.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.EX_Extent" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/AbstractObject_Type.xml">
+  <g:body>
+
+    <g:element g:targetName="gmd:description" minOccurs="0"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml">
+    </g:element>
+
+    <g:tabs g:extends="$base/core/ui/Tabs.xml">
+      <g:body>
+        <g:element g:targetName="gmd:geographicElement" minOccurs="0"  maxOccurs="unbounded"
+          g:extends="$base/schema/gmd/extent/EX_GeographicExtent_PropertyType.xml">
+        </g:element>
+
+        <g:element g:targetName="gmd:temporalElement" minOccurs="0"  maxOccurs="unbounded"
+          g:extends="$base/schema/gmd/extent/EX_TemporalExtent_PropertyType.xml">
+        </g:element>
+
+        <g:element g:targetName="gmd:verticalElement" minOccurs="0"  maxOccurs="unbounded"
+          g:extends="$base/schema/gmd/extent/EX_VerticalExtent_PropertyType.xml">
+        </g:element>
+      </g:body>
+    </g:tabs>
+
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/extent/EX_GeographicExtent_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/extent/EX_GeographicExtent_PropertyType.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/AbstractObject_Type.xml">
+  <g:body>
+
+    <g:element minOccurs="0" g:label="$i18n.catalog.iso19139.EX_GeographicExtent"
+        g:extends="$base/schema/gmd/extent/AbstractEX_GeographicExtent.xml">
+    </g:element>
+
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/extent/EX_TemporalExtent.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/extent/EX_TemporalExtent.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:EX_TemporalExtent"
+           g:extends="$base/schema/gmd/extent/EX_TemporalExtent_Type.xml">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/extent/EX_TemporalExtent_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/extent/EX_TemporalExtent_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gmd/extent/EX_TemporalExtent.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/extent/EX_TemporalExtent_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/extent/EX_TemporalExtent_Type.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.EX_TemporalExtent" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/AbstractObject_Type.xml">
+  <g:body>
+
+   <g:element g:targetName="gmd:extent" g:minOccurs="0" g:maxOccurs="1"
+      h:tag="div" g:jsClass="gxe.control.Element">
+        <g:element g:targetName="gml:TimePeriod" g:minOccurs="0" g:maxOccurs="1"
+          h:tag="div" g:jsClass="gxe.control.Element">
+          <g:attribute g:targetName="gml:id" g:value="Temporal"
+            g:rendered="false" g:jsClass="gxe.control.Attribute"/>
+          <g:element g:targetName="gml:beginPosition" g:minOccurs="0" g:maxOccurs="1"
+          g:value="#{EditMetadataController.now}"
+          g:valueType="xs:date"
+          g:extends="$base/xtn/ui/UI_ElementTextOnly.xml"/>
+        <g:element g:targetName="gml:endPosition" g:minOccurs="0" g:maxOccurs="1"
+          g:value="#{EditMetadataController.now}"
+          g:valueType="xs:date"
+          g:extends="$base/xtn/ui/UI_ElementTextOnly.xml"/>
+        </g:element>
+    </g:element>
+
+    <!--
+    <g:element g:targetName="gmd:extent"
+      g:extends="$base/schema/gts/temporalObjects/TM_Primitive_PropertyType.xml">
+    </g:element>
+    -->
+
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/extent/EX_VerticalExtent.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/extent/EX_VerticalExtent.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:EX_VerticalExtent"
+           g:extends="$base/schema/gmd/extent/EX_VerticalExtent_Type.xml">
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/extent/EX_VerticalExtent_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/extent/EX_VerticalExtent_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gmd/extent/EX_VerticalExtent.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/extent/EX_VerticalExtent_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/extent/EX_VerticalExtent_Type.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe"
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.EX_VerticalExtent" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/AbstractObject_Type.xml">
+  <g:body>
+
+    <g:element g:targetName="gmd:minimumValue"
+      g:extends="$base/schema/gco/basicTypes/Real_PropertyType.xml">
+    </g:element>
+
+    <g:element g:targetName="gmd:maximumValue"
+      g:extends="$base/schema/gco/basicTypes/Real_PropertyType.xml">
+    </g:element>
+
+    <g:element g:targetName="gmd:verticalCRS"
+      g:extends="$base/schema/gcr/spatialReferencing/SC_CRS_PropertyType.xml">
+    </g:element>
+
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/freeText/Country.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/freeText/Country.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:Country" 
+           g:i18nBase="catalog.iso19139.Country" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/CodeListValue_Type.xml">
+  <g:body>
+   
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeSpace.xml" 
+      g:value=""/>
+       
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeList.xml"
+      g:value=""/>
+     
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeListValue.xml">
+      <g:body>
+        <g:input g:extends="$base/core/ui/InputSelectOne.xml">
+          <g:options>
+            <g:option g:label="" g:value=""/>
+          </g:options>
+        </g:input>
+      </g:body>          
+    </g:attribute>     
+     
+  </g:body> 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/freeText/Country_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/freeText/Country_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/xtn/Wrapped_CodePropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gmd/freeText/Country.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/freeText/LanguageCode.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/freeText/LanguageCode.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:LanguageCode" 
+           g:i18nBase="catalog.iso19139.LanguageCode" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/CodeListValue_Type.xml">
+  <g:body>
+   
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeSpace.xml" 
+      g:value=""/>
+       
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeList.xml"
+      g:value=""/>
+     
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeListValue.xml">
+      <g:body>
+        <g:input g:extends="$base/core/ui/InputSelectOne.xml">
+          <g:options>
+            <g:option g:label="" g:value=""/>
+          </g:options>
+        </g:input>
+      </g:body>          
+    </g:attribute>     
+     
+  </g:body> 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/freeText/LanguageCode_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/freeText/LanguageCode_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/xtn/Wrapped_CodePropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gmd/freeText/LanguageCode.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/freeText/LocalisedCharacterString.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/freeText/LocalisedCharacterString.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:LocalisedCharacterString" 
+           g:extends="$base/schema/gmd/freeText/LocalisedCharacterString_Type.xml"/> 

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/freeText/LocalisedCharacterString_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/freeText/LocalisedCharacterString_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gmd/freeText/LocalisedCharacterString.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/freeText/LocalisedCharacterString_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/freeText/LocalisedCharacterString_Type.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.LocalisedCharacterString" g:label="$i18nBase"
+           g:extends="$base/core/xml/Element.xml">
+  <g:body>
+  
+	  <g:attribute g:targetNS="" g:targetName="id" g:use="optional" g:valueType="xs:ID"
+	    g:extends="$base/core/xml/Attribute.xml"/>
+	    
+    <g:attribute g:targetNS="" g:targetName="locale" g:use="optional" g:valueType="xs:anyURI"
+      g:extends="$base/core/xml/Attribute.xml"/>
+      
+    <g:textNode g:label="$i18nBase.textNode"
+      g:extends="$base/core/xml/TextNode.xml"/>
+
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/freeText/PT_FreeText.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/freeText/PT_FreeText.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:PT_FreeText" 
+           g:extends="$base/schema/gmd/freeText/PT_FreeText_Type.xml"/> 

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/freeText/PT_FreeText_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/freeText/PT_FreeText_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gmd/freeText/PT_LocaleContainer.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/freeText/PT_FreeText_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/freeText/PT_FreeText_Type.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.PT_FreeText" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/AbstractObject_Type.xml">
+  <g:body>
+      
+    <g:element g:targetName="gmd:textGroup" g:minOccurs="1" g:maxOccurs="unbounded"
+      g:extends="$base/schema/gmd/freeText/LocalisedCharacterString_PropertyType.xml"/>
+
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/freeText/PT_Locale.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/freeText/PT_Locale.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:PT_Locale" 
+           g:extends="$base/schema/gmd/freeText/PT_Locale_Type.xml"/> 

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/freeText/PT_LocaleContainer.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/freeText/PT_LocaleContainer.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:PT_LocaleContainer" 
+           g:extends="$base/schema/gmd/freeText/PT_LocaleContainer_Type.xml"/> 

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/freeText/PT_LocaleContainer_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/freeText/PT_LocaleContainer_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gmd/freeText/PT_LocaleContainer.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/freeText/PT_LocaleContainer_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/freeText/PT_LocaleContainer_Type.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.PT_LocaleContainer" g:label="$i18nBase"
+           g:extends="$base/core/xml/Element.xml">
+  <g:body>
+  
+    <g:element g:targetName="gmd:description" g:minOccurs="1" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+      
+    <g:element g:targetName="gmd:locale" g:minOccurs="1" g:maxOccurs="1"
+      g:extends="$base/schema/gmd/freeText/PT_Locale_PropertyType.xml"/>
+      
+    <g:element g:targetName="gmd:date" g:minOccurs="1" g:maxOccurs="unbounded"
+      g:extends="$base/schema/gmd/citation/CI_Date_PropertyType.xml"/>
+      
+    <g:element g:targetName="gmd:responsibleParty" g:minOccurs="1" g:maxOccurs="unbounded"
+      g:extends="$base/schema/gmd/citation/CI_ResponsibleParty_PropertyType.xml"/>
+      
+    <g:element g:targetName="gmd:localisedString" g:minOccurs="1" g:maxOccurs="unbounded"
+      g:extends="$base/schema/gmd/freeText/LocalisedCharacterString_PropertyType.xml"/>
+      
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/freeText/PT_Locale_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/freeText/PT_Locale_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gmd/freeText/PT_Locale.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/freeText/PT_Locale_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/freeText/PT_Locale_Type.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.PT_Locale" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/AbstractObject_Type.xml">
+  <g:body>
+  
+    <g:element g:targetName="gmd:languageCode" g:minOccurs="1" g:maxOccurs="1"
+      g:extends="$base/schema/gmd/freeText/LanguageCode_PropertyType.xml"/>
+      
+    <g:element g:targetName="gmd:country" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gmd/freeText/Country_PropertyType.xml"/>
+      
+    <g:element g:targetName="gmd:characterEncoding" g:minOccurs="1" g:maxOccurs="1"
+      g:extends="$base/schema/gmd/identification/MD_CharacterSetCode_PropertyType.xml"/>
+
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/AbstractMD_Identification.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/AbstractMD_Identification.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:AbstractMD_Identification" 
+           g:extends="$base/schema/gmd/identification/AbstractMD_Identification_Type.xml"/> 

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/AbstractMD_Identification_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/AbstractMD_Identification_Type.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/AbstractObject_Type.xml">
+  <g:annotation>
+    <g:documentation>Basic information about data</g:documentation>
+  </g:annotation>
+  <g:body>
+  
+    <g:tabs g:extends="$base/xtn/ui/UI_Tabs.xml">
+      <g:body>
+		    <g:element g:targetName="gmd:citation" g:minOccurs="1" g:maxOccurs="1"
+		      g:label="$i18n.catalog.iso19139.AbstractMD_Identification.citation"
+		      g:extends="$base/schema/gmd/citation/CI_Citation_PropertyType.xml"/>
+		      
+		    <g:element g:targetName="gmd:abstract" g:minOccurs="1" g:maxOccurs="1"
+		      g:label="$i18n.catalog.iso19139.AbstractMD_Identification.abstract"
+		      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml">
+		      <g:body>
+		        <g:element>
+		          <g:body>
+		            <g:input g:extends="$base/core/ui/InputTextArea.xml"/>
+		          </g:body>
+		        </g:element>
+		      </g:body>
+		    </g:element>
+		      
+		    <g:element g:targetName="gmd:purpose" g:minOccurs="0" g:maxOccurs="1"
+		      g:label="$i18n.catalog.iso19139.AbstractMD_Identification.purpose"
+		      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+		      
+		    <g:element g:targetName="gmd:credit" g:minOccurs="0" g:maxOccurs="unbounded"
+		      g:label="$i18n.catalog.iso19139.AbstractMD_Identification.credit"
+		      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+		      
+		    <g:element g:targetName="gmd:status" g:minOccurs="0" g:maxOccurs="unbounded"
+		      g:label="$i18n.catalog.iso19139.AbstractMD_Identification.status"
+		      g:extends="$base/schema/gmd/identification/MD_ProgressCode_PropertyType.xml"/>
+		      
+        <g:element g:targetName="gmd:pointOfContact" g:minOccurs="0" g:maxOccurs="unbounded"
+          g:label="$i18n.catalog.iso19139.AbstractMD_Identification.pointOfContact"
+          g:extends="$base/schema/gmd/citation/CI_ResponsibleParty_PropertyType.xml"/>
+          
+        <g:element g:targetName="gmd:resourceMaintenance" g:minOccurs="0" g:maxOccurs="unbounded"
+          g:label="$i18n.catalog.iso19139.AbstractMD_Identification.resourceMaintenance"
+          g:extends="$base/schema/gmd/maintenance/MD_MaintenanceInformation_PropertyType.xml"/>
+ 
+        <g:element g:targetName="gmd:graphicOverview" g:minOccurs="0" g:maxOccurs="unbounded"
+          g:label="$i18n.catalog.iso19139.AbstractMD_Identification.graphicOverview"
+          g:extends="$base/schema/gmd/identification/MD_BrowseGraphic_PropertyType.xml"/>     
+           
+        <g:tabs g:extends="$base/xtn/ui/UI_Tabs.xml" g:label="$i18n.catalog.gxe.general.more">
+          <g:body>  
+       
+				    <g:element g:targetName="gmd:resourceFormat" g:minOccurs="0" g:maxOccurs="unbounded"
+				      g:label="$i18n.catalog.iso19139.AbstractMD_Identification.resourceFormat"
+				      g:extends="$base/schema/gmd/distribution/MD_Format_PropertyType.xml"/>
+				
+				    <g:element g:targetName="gmd:descriptiveKeywords" g:minOccurs="0" g:maxOccurs="unbounded"
+				      g:label="$i18n.catalog.iso19139.AbstractMD_Identification.descriptiveKeywords"
+				      g:extends="$base/schema/gmd/identification/MD_Keywords_PropertyType.xml"/>
+				      
+				    <g:element g:targetName="gmd:resourceSpecificUsage" g:minOccurs="0" g:maxOccurs="unbounded"
+				      g:label="$i18n.catalog.iso19139.AbstractMD_Identification.resourceSpecificUsage"
+				      g:extends="$base/schema/gmd/identification/MD_Usage_PropertyType.xml"/>
+
+                    <g:element g:targetName="gmd:resourceConstraints" minOccurs="0" maxOccurs="unbounded"
+                      g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">
+                        <g:body>
+                          <g:elementChoice g:minOccurs="0" g:extends="$base/xtn/ui/UI_ElementChoice.xml">
+                            <g:body>
+                              <g:import g:src="$base/schema/gmd/constraints/MD_Constraints.xml"/>
+                              <g:import g:src="$base/schema/gmd/constraints/MD_LegalConstraints.xml"/>
+                              <g:import g:src="$base/schema/gmd/constraints/MD_SecurityConstraints.xml"/>
+                            </g:body>
+                          </g:elementChoice>
+                        </g:body>
+                    </g:element>
+				      
+				    <g:element g:targetName="gmd:aggregationInfo" g:minOccurs="0" g:maxOccurs="unbounded"
+				      g:label="$i18n.catalog.iso19139.AbstractMD_Identification.aggregationInfo"
+				      g:extends="$base/schema/gmd/identification/MD_AggregateInformation_PropertyType.xml"/>
+ 
+	        </g:body>
+	      </g:tabs>
+         
+      </g:body>
+    </g:tabs>
+          
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/DS_Association.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/DS_Association.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:DS_Association" 
+           g:extends="$base/schema/gmd/identification/DS_Association_Type.xml"/> 

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/DS_AssociationTypeCode.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/DS_AssociationTypeCode.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:DS_AssociationTypeCode" 
+           g:i18nBase="catalog.iso19139.DS_AssociationTypeCode" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/CodeListValue_Type.xml">
+  <g:body>
+   
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeSpace.xml" 
+      g:value="ISOTC211/19115"/>
+       
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeList.xml"
+      g:value="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#DS_AssociationTypeCode"/>
+     
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeListValue.xml">
+      <g:body>
+        <g:input g:extends="$base/core/ui/InputSelectOne.xml">
+          <g:options>
+            <g:option g:label="" g:value=""/>
+            <g:option g:label="$i18nBase.crossReference" g:value="crossReference"/>
+            <g:option g:label="$i18nBase.largerWorkCitation" g:value="largerWorkCitation"/>
+            <g:option g:label="$i18nBase.partOfSeamlessDatabase" g:value="partOfSeamlessDatabase"/>
+            <g:option g:label="$i18nBase.source" g:value="source"/>
+            <g:option g:label="$i18nBase.stereoMate" g:value="stereoMate"/>
+          </g:options>
+        </g:input>
+      </g:body>          
+    </g:attribute>     
+     
+  </g:body> 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/DS_AssociationTypeCode_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/DS_AssociationTypeCode_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/xtn/Wrapped_CodePropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" 
+      g:extends="$base/schema/gmd/identification/DS_AssociationTypeCode.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/DS_Association_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/DS_Association_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" 
+      g:extends="$base/schema/gmd/identification/DS_Association.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/DS_Association_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/DS_Association_Type.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.DS_Association" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/AbstractObject_Type.xml"/>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/DS_InitiativeTypeCode.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/DS_InitiativeTypeCode.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:DS_InitiativeTypeCode" 
+           g:i18nBase="catalog.iso19139.DS_InitiativeTypeCode" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/CodeListValue_Type.xml">
+  <g:body>
+   
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeSpace.xml" 
+      g:value="ISOTC211/19115"/>
+       
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeList.xml"
+      g:value="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#DS_InitiativeTypeCode"/>
+     
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeListValue.xml">
+      <g:body>
+        <g:input g:extends="$base/core/ui/InputSelectOne.xml">
+          <g:options>
+            <g:option g:label="" g:value=""/>
+            <g:option g:label="$i18nBase.campaign" g:value="campaign"/>
+            <g:option g:label="$i18nBase.collection" g:value="collection"/>
+            <g:option g:label="$i18nBase.exercise" g:value="exercise"/>
+            <g:option g:label="$i18nBase.experiment" g:value="experiment"/>
+            <g:option g:label="$i18nBase.investigation" g:value="investigation"/>
+            <g:option g:label="$i18nBase.mission" g:value="mission"/>
+            <g:option g:label="$i18nBase.sensor" g:value="sensor"/>
+            <g:option g:label="$i18nBase.operation" g:value="operation"/>
+            <g:option g:label="$i18nBase.platform" g:value="platform"/>
+            <g:option g:label="$i18nBase.process" g:value="process"/>
+            <g:option g:label="$i18nBase.program" g:value="program"/>
+            <g:option g:label="$i18nBase.project" g:value="project"/>
+            <g:option g:label="$i18nBase.study" g:value="study"/>
+            <g:option g:label="$i18nBase.task" g:value="task"/>
+            <g:option g:label="$i18nBase.trial" g:value="trial"/>
+          </g:options>
+        </g:input>
+      </g:body>          
+    </g:attribute>     
+     
+  </g:body> 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/DS_InitiativeTypeCode_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/DS_InitiativeTypeCode_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/xtn/Wrapped_CodePropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" 
+      g:extends="$base/schema/gmd/identification/DS_InitiativeTypeCode.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_AggregateInformation.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_AggregateInformation.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_AggregateInformation" 
+           g:extends="$base/schema/gmd/identification/MD_AggregateInformation_Type.xml"/> 

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_AggregateInformation_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_AggregateInformation_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" 
+      g:extends="$base/schema/gmd/identification/MD_AggregateInformation.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_AggregateInformation_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_AggregateInformation_Type.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.MD_AggregateInformation" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/AbstractObject_Type.xml">
+  <g:annotation>
+    <g:documentation>Encapsulates the dataset aggregation information</g:documentation>
+  </g:annotation>
+  <g:body>
+  
+    <g:element g:targetName="gmd:aggregateDataSetName" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gmd/citation/CI_Citation_PropertyType.xml"/>
+    
+    <g:element g:targetName="gmd:aggregateDataSetIdentifier" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gmd/referenceSystem/MD_Identifier_PropertyType.xml"/>
+      
+    <g:element g:targetName="gmd:associationType" g:minOccurs="1" g:maxOccurs="1"
+      g:extends="$base/schema/gmd/identification/DS_AssociationTypeCode_PropertyType.xml"/>
+      
+    <g:element g:targetName="gmd:initiativeType" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gmd/identification/DS_InitiativeTypeCode_PropertyType.xml"/>
+    
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_BrowseGraphic.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_BrowseGraphic.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_BrowseGraphic" 
+           g:extends="$base/schema/gmd/identification/MD_BrowseGraphic_Type.xml"/> 

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_BrowseGraphic_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_BrowseGraphic_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" 
+      g:extends="$base/schema/gmd/identification/MD_BrowseGraphic.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_BrowseGraphic_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_BrowseGraphic_Type.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.MD_BrowseGraphic" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/AbstractObject_Type.xml">
+  <g:annotation>
+    <g:documentation>Graphic that provides an illustration of the dataset (should include a legend for the graphic)</g:documentation>
+  </g:annotation>
+  <g:body>
+  
+    <g:element g:targetName="gmd:fileName" g:minOccurs="1" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+    
+    <g:element g:targetName="gmd:fileDescription" g:minOccurs="0" g:maxOccurs="1"
+       g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+      
+    <g:element g:targetName="gmd:fileType" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+          
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_CharacterSetCode.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_CharacterSetCode.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_CharacterSetCode" 
+           g:i18nBase="catalog.iso19139.MD_CharacterSetCode" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/CodeListValue_Type.xml">
+  <g:body>
+   
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeSpace.xml" 
+      g:value="ISOTC211/19115"/>
+       
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeList.xml"
+      g:value="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_CharacterSetCode"/>
+     
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeListValue.xml">
+      <g:body>
+        <g:input g:extends="$base/core/ui/InputSelectOne.xml">
+          <g:options>
+            <g:option g:label="" g:value=""/>
+            <g:option g:label="$i18nBase.ucs2" g:value="ucs2"/>
+            <g:option g:label="$i18nBase.ucs4" g:value="ucs4"/>
+            <g:option g:label="$i18nBase.utf7" g:value="utf7"/>
+            <g:option g:label="$i18nBase.utf8" g:value="utf8"/>
+            <g:option g:label="$i18nBase.utf16" g:value="utf16"/>
+            <g:option g:label="$i18nBase.8859part1" g:value="8859part1"/>
+            <g:option g:label="$i18nBase.8859part2" g:value="8859part2"/>
+            <g:option g:label="$i18nBase.8859part3" g:value="8859part3"/>
+            <g:option g:label="$i18nBase.8859part4" g:value="8859part4"/>
+            <g:option g:label="$i18nBase.8859part5" g:value="8859part5"/>
+            <g:option g:label="$i18nBase.8859part6" g:value="8859part6"/>
+            <g:option g:label="$i18nBase.8859part7" g:value="8859part7"/>
+            <g:option g:label="$i18nBase.8859part8" g:value="8859part8"/>
+            <g:option g:label="$i18nBase.8859part9" g:value="8859part9"/>
+            <g:option g:label="$i18nBase.8859part10" g:value="8859part10"/>
+            <g:option g:label="$i18nBase.8859part11" g:value="8859part11"/>
+            <!--  reserved <g:option g:label="$i18nBase.8859part12" g:value="8859part12"/> -->
+            <g:option g:label="$i18nBase.8859part13" g:value="8859part13"/>
+            <g:option g:label="$i18nBase.8859part14" g:value="8859part14"/>
+            <g:option g:label="$i18nBase.8859part15" g:value="8859part15"/>
+            <g:option g:label="$i18nBase.8859part16" g:value="8859part16"/>
+            <g:option g:label="$i18nBase.jis" g:value="jis"/>
+            <g:option g:label="$i18nBase.shiftJIS" g:value="shiftJIS"/>
+            <g:option g:label="$i18nBase.eucJP" g:value="eucJP"/>
+            <g:option g:label="$i18nBase.usAscii" g:value="usAscii"/>
+            <g:option g:label="$i18nBase.ebcdic" g:value="ebcdic"/>
+            <g:option g:label="$i18nBase.eucKR" g:value="eucKR"/>
+            <g:option g:label="$i18nBase.big5" g:value="big5"/>
+            <g:option g:label="$i18nBase.GB2312" g:value="GB2312"/>
+          </g:options>
+        </g:input>
+      </g:body>          
+    </g:attribute>     
+     
+  </g:body> 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_CharacterSetCode_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_CharacterSetCode_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/xtn/Wrapped_CodePropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" 
+      g:extends="$base/schema/gmd/identification/MD_CharacterSetCode.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_DataIdentification.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_DataIdentification.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_DataIdentification" 
+           g:extends="$base/schema/gmd/identification/MD_DataIdentification_Type.xml"/> 

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_DataIdentification_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_DataIdentification_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" 
+      g:extends="$base/schema/gmd/identification/MD_DataIdentification.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_DataIdentification_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_DataIdentification_Type.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.MD_DataIdentification" g:label="$i18nBase"
+           g:extends="$base/schema/gmd/identification/AbstractMD_Identification_Type.xml">
+  <g:body>
+  
+    <g:tabs>
+      <g:body>
+        <g:tabs>
+          <g:body>
+          
+            <g:element g:targetName="gmd:spatialRepresentationType" g:minOccurs="0" g:maxOccurs="unbounded"
+              g:extends="$base/schema/gmd/identification/MD_SpatialRepresentationTypeCode_PropertyType.xml"/>
+
+            <g:element g:targetName="gmd:spatialResolution" g:minOccurs="0" g:maxOccurs="unbounded"
+              g:extends="$base/schema/gmd/identification/MD_Resolution_PropertyType.xml"/>
+
+            <g:tabs g:extends="$base/xtn/ui/UI_Tabs.xml" g:label="$i18n.catalog.gxe.general.more">
+              <g:body>  
+						      
+						    <g:element g:targetName="gmd:language" g:minOccurs="1" g:maxOccurs="unbounded"
+						      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+						      
+						    <g:element g:targetName="gmd:characterSet" g:minOccurs="0" g:maxOccurs="unbounded"
+						      g:extends="$base/schema/gmd/identification/MD_CharacterSetCode_PropertyType.xml"/>
+						      
+						    <g:element g:targetName="gmd:topicCategory" g:minOccurs="0" g:maxOccurs="unbounded"
+						      g:extends="$base/schema/gmd/identification/MD_TopicCategoryCode_PropertyType.xml"/>
+						      
+						    <g:element g:targetName="gmd:environmentDescription" g:minOccurs="0" g:maxOccurs="1"
+						      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+						    
+						    <g:element g:targetName="gmd:extent" g:minOccurs="0" g:maxOccurs="unbounded"
+						      g:extends="$base/schema/gmd/extent/EX_Extent_PropertyType.xml"/>
+						      
+						    <g:element g:targetName="gmd:supplementalInformation" g:minOccurs="0" g:maxOccurs="1"
+						      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+ 
+			        </g:body>
+            </g:tabs>
+    
+	        </g:body>
+	      </g:tabs>
+    
+      </g:body>
+    </g:tabs>
+             
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_Identification_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_Identification_PropertyType.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+  
+    <!--
+    <g:element g:minOccurs="0" 
+      g:extends="$base/schema/gmd/identification/AbstractMD_Identification.xml"/>
+    -->
+    
+    <g:elementChoice g:minOccurs="0" g:extends="$base/xtn/ui/UI_ElementChoice.xml">
+      <g:body>
+        <g:element g:extends="$base/schema/gmd/identification/MD_DataIdentification.xml"/>
+        <!-- TODO: shall SV_ServiceIdentification be here? -->
+        <g:element g:extends="$base/schema/srv/serviceMetadata/SV_ServiceIdentification.xml"/>
+        
+        <!-- TODO requires implementation 
+        <g:element g:extends="$base/schema/gmd/identification/MD_ServiceIdentification.xml"/>-->
+        
+      </g:body>
+    </g:elementChoice>
+          
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_KeywordTypeCode.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_KeywordTypeCode.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_KeywordTypeCode" 
+           g:i18nBase="catalog.iso19139.MD_KeywordTypeCode" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/CodeListValue_Type.xml">
+  <g:body>
+   
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeSpace.xml" 
+      g:value="ISOTC211/19115"/>
+       
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeList.xml"
+      g:value="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode"/>
+     
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeListValue.xml">
+      <g:body>
+        <g:input g:extends="$base/core/ui/InputSelectOne.xml">
+          <g:options>
+            <g:option g:label="" g:value=""/>
+            <g:option g:label="$i18nBase.discipline" g:value="discipline"/>
+            <g:option g:label="$i18nBase.place" g:value="place"/>
+            <g:option g:label="$i18nBase.stratum" g:value="stratum"/>
+            <g:option g:label="$i18nBase.temporal" g:value="temporal"/>
+            <g:option g:label="$i18nBase.theme" g:value="theme"/>
+          </g:options>
+        </g:input>
+      </g:body>          
+    </g:attribute>     
+     
+  </g:body> 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_KeywordTypeCode_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_KeywordTypeCode_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/xtn/Wrapped_CodePropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" 
+      g:extends="$base/schema/gmd/identification/MD_KeywordTypeCode.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_Keywords.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_Keywords.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_Keywords" 
+           g:extends="$base/schema/gmd/identification/MD_Keywords_Type.xml"/> 

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_Keywords_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_Keywords_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" 
+      g:extends="$base/schema/gmd/identification/MD_Keywords.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_Keywords_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_Keywords_Type.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.MD_Keywords" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/AbstractObject_Type.xml">
+  <g:annotation>
+    <g:documentation>Keywords, their type and reference source</g:documentation>
+  </g:annotation>
+  <g:body>
+  
+    <!-- MODIFIED - the container below mirrors the original XSD structure -->
+    <g:container g:rendered="$editor.isOriginalMode">
+    
+	    <g:element g:targetName="gmd:keyword" g:minOccurs="1" g:maxOccurs="unbounded"
+	      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+	    
+	    <g:element g:targetName="gmd:type" g:minOccurs="0" g:maxOccurs="1"
+	      g:extends="$base/schema/gmd/identification/MD_KeywordTypeCode_PropertyType.xml"/>
+	      
+	    <g:element g:targetName="gmd:thesaurusName" g:minOccurs="0" g:maxOccurs="1"
+	      g:extends="$base/schema/gmd/citation/CI_Citation_PropertyType.xml"/>
+      
+    </g:container>
+    
+    
+    <!-- MODIFIED - the container below produces a simplified structure --> 
+    <g:container g:rendered="$editor.isSimplifiedMode">
+    
+      <g:element g:targetName="gmd:keyword" g:minOccurs="1" g:maxOccurs="unbounded"
+        g:label="$i18n.catalog.iso19139.MD_Keywords.keyword.delimited"
+        g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml">
+        <g:body>
+          <g:element g:isIsoWMVL="true">
+            <g:body>
+              <g:input g:extends="$base/core/ui/InputDelimitedTextArea.xml"/>
+            </g:body>
+          </g:element>
+        </g:body>
+      </g:element>
+      
+      <g:element g:targetName="gmd:type" g:minOccurs="0" g:maxOccurs="1"
+        g:extends="$base/schema/gmd/identification/MD_KeywordTypeCode_PropertyType.xml"/>
+        
+      <g:element g:targetName="gmd:thesaurusName" g:minOccurs="0" g:maxOccurs="1"
+        g:extends="$base/xtn/ui/UI_Element.xml">
+        <g:body>
+          <g:element g:targetName="gmd:CI_Citation" g:minOccurs="0" g:maxOccurs="1"
+            g:i18nBase="catalog.iso19139.CI_Citation"
+            h:tag="div" g:jsClass="gxe.control.Element">
+          
+            <g:element g:targetName="gmd:title" g:minOccurs="1" g:maxOccurs="1" 
+              g:label="$i18n.catalog.iso19139.CI_Citation.specification.title"
+              g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+              
+            <g:element g:targetName="gmd:date" g:minOccurs="1" g:maxOccurs="unbounded"
+              g:label="$i18n.catalog.iso19139.CI_Citation.specification.date"
+              g:extends="$base/schema/gmd/citation/CI_Date_PropertyType.xml"/>
+              
+           </g:element> 
+         </g:body>
+      </g:element>
+         
+    </g:container>
+     
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_ProgressCode.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_ProgressCode.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_ProgressCode" 
+           g:i18nBase="catalog.iso19139.MD_ProgressCode" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/CodeListValue_Type.xml">
+  <g:body>
+   
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeSpace.xml" 
+      g:value="ISOTC211/19115"/>
+       
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeList.xml"
+      g:value="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_ProgressCode"/>
+     
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeListValue.xml">
+      <g:body>
+        <g:input g:extends="$base/core/ui/InputSelectOne.xml">
+          <g:options>
+            <g:option g:label="" g:value=""/>
+            <g:option g:label="$i18nBase.completed" g:value="completed"/>
+            <g:option g:label="$i18nBase.historicalArchive" g:value="historicalArchive"/>
+            <g:option g:label="$i18nBase.obsolete" g:value="obsolete"/>
+            <g:option g:label="$i18nBase.onGoing" g:value="onGoing"/>
+            <g:option g:label="$i18nBase.planned" g:value="planned"/>
+            <g:option g:label="$i18nBase.required" g:value="required"/>
+            <g:option g:label="$i18nBase.underDevelopment" g:value="underDevelopment"/>
+          </g:options>
+        </g:input>
+      </g:body>          
+    </g:attribute>     
+     
+  </g:body> 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_ProgressCode_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_ProgressCode_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/xtn/Wrapped_CodePropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" 
+      g:extends="$base/schema/gmd/identification/MD_ProgressCode.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_RepresentativeFraction.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_RepresentativeFraction.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_RepresentativeFraction" 
+           g:extends="$base/schema/gmd/identification/MD_RepresentativeFraction_Type.xml"/> 

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_RepresentativeFraction_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_RepresentativeFraction_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" 
+      g:extends="$base/schema/gmd/identification/MD_RepresentativeFraction.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_RepresentativeFraction_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_RepresentativeFraction_Type.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.MD_RepresentativeFraction" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/AbstractObject_Type.xml">
+  <g:body>
+  
+    <g:element g:targetName="gmd:denominator" g:minOccurs="1" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/Integer_PropertyType.xml"/>
+          
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_Resolution.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_Resolution.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_Resolution" 
+           g:extends="$base/schema/gmd/identification/MD_Resolution_Type.xml"/> 

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_Resolution_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_Resolution_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/xtn/Wrapped_BasicPropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" 
+      g:extends="$base/schema/gmd/identification/MD_Resolution.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_Resolution_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_Resolution_Type.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.MD_Resolution" g:label="$i18nBase"
+           g:extends="$base/xtn/ui/UI_Wrapped_Element.xml">
+  <g:body>
+  
+    <g:elementChoice g:minOccurs="1" g:extends="$base/xtn/ui/UI_ElementChoice.xml">
+      <g:body>
+      
+        <g:element g:targetName="gmd:equivalentScale" g:minOccurs="1" g:maxOccurs="1"
+          g:extends="$base/schema/gmd/identification/MD_RepresentativeFraction_PropertyType.xml"/>
+    
+        <g:element g:targetName="gmd:distance" g:minOccurs="1" g:maxOccurs="1"
+          g:extends="$base/schema/gco/basicTypes/Distance_PropertyType.xml"/>      
+  
+      </g:body>
+    </g:elementChoice>      
+    
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_ServiceIdentification.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_ServiceIdentification.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_ServiceIdentification" 
+           g:extends="$base/schema/gmd/identification/MD_ServiceIdentification_Type.xml"/> 

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_ServiceIdentification_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_ServiceIdentification_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" 
+      g:extends="$base/schema/gmd/identification/MD_ServiceIdentification.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_ServiceIdentification_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_ServiceIdentification_Type.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.MD_ServiceIdentification" g:label="$i18nBase"
+           g:extends="$base/schema/gmd/identification/AbstractMD_Identification_Type.xml">
+  <g:annotation>
+    <g:documentation>See 19119 for further info</g:documentation>
+  </g:annotation>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_SpatialRepresentationTypeCode.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_SpatialRepresentationTypeCode.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_SpatialRepresentationTypeCode" 
+           g:i18nBase="catalog.iso19139.MD_SpatialRepresentationTypeCode" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/CodeListValue_Type.xml">
+  <g:body>
+   
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeSpace.xml" 
+      g:value="ISOTC211/19115"/>
+       
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeList.xml"
+      g:value="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_SpatialRepresentationTypeCode"/>
+     
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeListValue.xml">
+      <g:body>
+        <g:input g:extends="$base/core/ui/InputSelectOne.xml">
+          <g:options>
+            <g:option g:label="" g:value=""/>
+            <g:option g:label="$i18nBase.vector" g:value="vector"/>
+            <g:option g:label="$i18nBase.grid" g:value="grid"/>
+            <g:option g:label="$i18nBase.textTable" g:value="textTable"/>
+            <g:option g:label="$i18nBase.tin" g:value="tin"/>
+            <g:option g:label="$i18nBase.stereoModel" g:value="stereoModel"/>
+            <g:option g:label="$i18nBase.video" g:value="video"/>
+          </g:options>
+        </g:input>
+      </g:body>          
+    </g:attribute>     
+     
+  </g:body> 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_SpatialRepresentationTypeCode_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_SpatialRepresentationTypeCode_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/xtn/Wrapped_CodePropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" 
+      g:extends="$base/schema/gmd/identification/MD_SpatialRepresentationTypeCode.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_TopicCategoryCode.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_TopicCategoryCode.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_TopicCategoryCode" 
+           g:extends="$base/schema/gmd/identification/MD_TopicCategoryCode_Type.xml"/>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_TopicCategoryCode_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_TopicCategoryCode_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/xtn/Wrapped_CodePropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="$parent" 
+      g:extends="$base/schema/gmd/identification/MD_TopicCategoryCode.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_TopicCategoryCode_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_TopicCategoryCode_Type.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.MD_TopicCategoryCode" g:label="$i18nBase"
+           g:isIsoWMVL="true"
+           g:extends="$base/xtn/ui/UI_Wrapped_ElementTextOnly.xml">
+  <g:annotation>
+    <g:documentation>High-level geospatial data thematic classification to assist in the grouping and search of available geospatial datasets</g:documentation>
+  </g:annotation>
+  <g:body>
+    <g:input g:extends="$base/core/ui/InputSelectMany.xml">
+      <g:options>
+        <!-- <g:option g:label="" g:value=""/> -->
+        <g:option g:label="$i18nBase.boundaries" g:value="boundaries"/>
+        <g:option g:label="$i18nBase.farming" g:value="farming"/>
+        <g:option g:label="$i18nBase.climatologyMeteorologyAtmosphere" g:value="climatologyMeteorologyAtmosphere"/>
+        <g:option g:label="$i18nBase.biota" g:value="biota"/>
+        <g:option g:label="$i18nBase.economy" g:value="economy"/>
+        <g:option g:label="$i18nBase.planningCadastre" g:value="planningCadastre"/>
+        <g:option g:label="$i18nBase.society" g:value="society"/>
+        <g:option g:label="$i18nBase.elevation" g:value="elevation"/>
+        <g:option g:label="$i18nBase.environment" g:value="environment"/>
+        <g:option g:label="$i18nBase.structure" g:value="structure"/>
+        <g:option g:label="$i18nBase.geoscientificInformation" g:value="geoscientificInformation"/>
+        <g:option g:label="$i18nBase.health" g:value="health"/>
+        <g:option g:label="$i18nBase.imageryBaseMapsEarthCover" g:value="imageryBaseMapsEarthCover"/>
+        <g:option g:label="$i18nBase.inlandWaters" g:value="inlandWaters"/>
+        <g:option g:label="$i18nBase.location" g:value="location"/>
+        <g:option g:label="$i18nBase.intelligenceMilitary" g:value="intelligenceMilitary"/>
+        <g:option g:label="$i18nBase.oceans" g:value="oceans"/>
+        <g:option g:label="$i18nBase.transportation" g:value="transportation"/>
+        <g:option g:label="$i18nBase.utilitiesCommunication" g:value="utilitiesCommunication"/>
+      </g:options>
+    </g:input>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_Usage.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_Usage.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_Usage" 
+           g:extends="$base/schema/gmd/identification/MD_Usage_Type.xml"/> 

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_Usage_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_Usage_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" 
+      g:extends="$base/schema/gmd/identification/MD_Usage.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_Usage_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/identification/MD_Usage_Type.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.MD_Usage" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/AbstractObject_Type.xml">
+  <g:annotation>
+    <g:documentation>Brief description of ways in which the dataset is currently used.</g:documentation>
+  </g:annotation>
+  <g:body>
+  
+    <g:element g:targetName="gmd:specificUsage" g:minOccurs="1" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+    
+    <g:element g:targetName="gmd:usageDateTime" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/DateTime_PropertyType.xml"/>
+      
+    <g:element g:targetName="gmd:userDeterminedLimitations" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+      
+    <g:element g:targetName="gmd:userContactInfo" g:minOccurs="1" g:maxOccurs="unbounded"
+      g:extends="$base/schema/gmd/citation/CI_ResponsibleParty_PropertyType.xml"/>
+          
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/maintenance/MD_MaintenanceFrequencyCode.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/maintenance/MD_MaintenanceFrequencyCode.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_MaintenanceFrequencyCode" 
+           g:i18nBase="catalog.iso19139.MD_MaintenanceFrequencyCode" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/CodeListValue_Type.xml">
+  <g:body>
+   
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeSpace.xml" 
+      g:value="ISOTC211/19115"/>
+       
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeList.xml"
+      g:value="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_MaintenanceFrequencyCode"/>
+     
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeListValue.xml">
+      <g:body>
+        <g:input g:extends="$base/core/ui/InputSelectOne.xml">
+          <g:options>
+            <g:option g:label="" g:value="" />
+            <g:option g:label="$i18nBase.continual" g:value="continual"/>
+            <g:option g:label="$i18nBase.daily" g:value="daily"/>
+            <g:option g:label="$i18nBase.weekly" g:value="weekly"/>
+            <g:option g:label="$i18nBase.fortnightly" g:value="fortnightly"/>
+            <g:option g:label="$i18nBase.monthly" g:value="monthly"/>
+            <g:option g:label="$i18nBase.quarterly" g:value="quarterly"/>
+            <g:option g:label="$i18nBase.biannually" g:value="biannually"/>
+            <g:option g:label="$i18nBase.annually" g:value="annually"/>
+            <g:option g:label="$i18nBase.asNeeded" g:value="asNeeded"/>
+            <g:option g:label="$i18nBase.irregular" g:value="irregular"/>
+            <g:option g:label="$i18nBase.notPlanned" g:value="notPlanned"/>
+            <g:option g:label="$i18nBase.unknown" g:value="unknown"/>
+          </g:options>
+        </g:input>
+      </g:body>          
+    </g:attribute>     
+     
+  </g:body> 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/maintenance/MD_MaintenanceFrequencyCode_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/maintenance/MD_MaintenanceFrequencyCode_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/xtn/Wrapped_CodePropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gmd/maintenance/MD_MaintenanceFrequencyCode.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/maintenance/MD_MaintenanceInformation.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/maintenance/MD_MaintenanceInformation.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_MaintenanceInformation" 
+           g:extends="$base/schema/gmd/maintenance/MD_MaintenanceInformation_Type.xml"> 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/maintenance/MD_MaintenanceInformation_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/maintenance/MD_MaintenanceInformation_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" 
+      g:extends="$base/schema/gmd/maintenance/MD_MaintenanceInformation.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/maintenance/MD_MaintenanceInformation_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/maintenance/MD_MaintenanceInformation_Type.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.MD_MaintenanceInformation" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/AbstractObject_Type.xml">
+  <g:annotation>
+    <g:documentation>Information about the scope and frequency of updating</g:documentation>
+  </g:annotation>
+  <g:body>
+
+    <g:element g:targetName="gmd:maintenanceAndUpdateFrequency" g:minOccurs="1" g:maxOccurs="1"
+      g:extends="$base/schema/gmd/maintenance/MD_MaintenanceFrequencyCode_PropertyType.xml"/>
+
+    <g:tabs g:extends="$base/xtn/ui/UI_Tabs.xml">
+	    <g:body>      
+      
+        <g:element g:targetName="gmd:dateOfNextUpdate" g:minOccurs="0" g:maxOccurs="1"
+          g:extends="$base/schema/gco/basicTypes/Date_PropertyType.xml"/>
+          
+		    <!-- TODO requires implementation 
+		    <g:element g:targetName="gmd:userDefinedMaintenanceFrequency" g:minOccurs="0" g:maxOccurs="1"
+		      g:extends="$base/qts/TM_PeriodDuration_PropertyType.xml"/>
+		    -->
+      
+		    <g:element g:targetName="gmd:updateScope" g:minOccurs="0" g:maxOccurs="unbounded"
+		      g:extends="$base/schema/gmd/maintenance/MD_ScopeCode_PropertyType.xml"/>
+		      
+		    <g:element g:targetName="gmd:updateScopeDescription" g:minOccurs="0" g:maxOccurs="unbounded"
+		      g:extends="$base/schema/gmd/maintenance/MD_ScopeDescription_PropertyType.xml"/>
+		      
+		    <g:element g:targetName="gmd:maintenanceNote" g:minOccurs="0" g:maxOccurs="unbounded"
+		      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+		      
+		    <g:element g:targetName="gmd:contact" g:minOccurs="0" g:maxOccurs="unbounded"
+		      g:extends="$base/schema/gmd/citation/CI_ResponsibleParty_PropertyType.xml"/>
+		      
+      </g:body>
+    </g:tabs> 
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/maintenance/MD_ScopeCode.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/maintenance/MD_ScopeCode.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_ScopeCode" 
+           g:i18nBase="catalog.iso19139.MD_ScopeCode" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/CodeListValue_Type.xml">
+  <g:body>
+   
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeSpace.xml" 
+      g:value="ISOTC211/19115"/>
+       
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeList.xml"
+      g:value="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_ScopeCode"/>
+     
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeListValue.xml">
+      <g:body>
+        <g:input g:extends="$base/core/ui/InputSelectOne.xml">
+          <g:options>
+            <g:option g:label="" g:value=""/>
+            <g:option g:label="$i18nBase.attribute" g:value="attribute"/>
+            <g:option g:label="$i18nBase.attributeType" g:value="attributeType"/>
+            <g:option g:label="$i18nBase.collectionHardware" g:value="collectionHardware"/>
+            <g:option g:label="$i18nBase.collectionSession" g:value="collectionSession"/>
+            <g:option g:label="$i18nBase.dataset" g:value="dataset"/>
+            <g:option g:label="$i18nBase.series" g:value="series"/>
+            <g:option g:label="$i18nBase.nonGeographicDataset" g:value="nonGeographicDataset"/>
+            <g:option g:label="$i18nBase.dimensionGroup" g:value="dimensionGroup"/>
+            <g:option g:label="$i18nBase.feature" g:value="feature"/>
+            <g:option g:label="$i18nBase.featureType" g:value="featureType"/>
+            <g:option g:label="$i18nBase.propertyType" g:value="propertyType"/>
+            <g:option g:label="$i18nBase.fieldSession" g:value="fieldSession"/>
+            <g:option g:label="$i18nBase.software" g:value="software"/>
+            <g:option g:label="$i18nBase.service" g:value="service"/>
+            <g:option g:label="$i18nBase.model" g:value="model"/>
+            <g:option g:label="$i18nBase.tile" g:value="tile"/>
+          </g:options>
+        </g:input>
+      </g:body>          
+    </g:attribute>     
+     
+  </g:body> 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/maintenance/MD_ScopeCode_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/maintenance/MD_ScopeCode_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/xtn/Wrapped_CodePropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gmd/maintenance/MD_ScopeCode.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/maintenance/MD_ScopeDescription.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/maintenance/MD_ScopeDescription.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_ScopeDescription" 
+           g:extends="$base/schema/gmd/maintenance/MD_ScopeDescription_Type.xml"> 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/maintenance/MD_ScopeDescription_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/maintenance/MD_ScopeDescription_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/xtn/Wrapped_BasicPropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" 
+      g:extends="$base/schema/gmd/maintenance/MD_ScopeDescription.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/maintenance/MD_ScopeDescription_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/maintenance/MD_ScopeDescription_Type.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.MD_ScopeDescription" g:label="$i18nBase"
+           g:extends="$base/xtn/ui/UI_Wrapped_Element.xml">
+  <g:annotation>
+    <g:documentation>Description of the class of information covered by the information</g:documentation>
+  </g:annotation>
+  <g:body>
+  
+    <g:elementChoice g:minOccurs="1" g:extends="$base/xtn/ui/UI_ElementChoice.xml">
+      <g:body>
+      
+        <g:element g:targetName="gmd:attributes" g:minOccurs="1" g:maxOccurs="unbounded"
+          g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml"/>
+    
+        <g:element g:targetName="gmd:features" g:minOccurs="1" g:maxOccurs="unbounded"
+          g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml"/>
+          
+        <g:element g:targetName="gmd:featureInstances" g:minOccurs="1" g:maxOccurs="unbounded"
+          g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml"/>
+          
+        <g:element g:targetName="gmd:attributeInstances" g:minOccurs="1" g:maxOccurs="unbounded"
+          g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml"/>      
+    
+        <g:element g:targetName="gmd:dataset" g:minOccurs="1" g:maxOccurs="1"
+          g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/> 
+          
+        <g:element g:targetName="gmd:other" g:minOccurs="1" g:maxOccurs="1"
+          g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>       
+  
+      </g:body>
+    </g:elementChoice>      
+    
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataApplication/AbstractDS_Aggregate.xml.txt
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataApplication/AbstractDS_Aggregate.xml.txt
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:AbstractDS_Aggregate" 
+           g:extends="$base/schema/gmd/metadataApplication/AbstractDS_Aggregate_Type.xml"> 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataApplication/AbstractDS_Aggregate_Type.xml.txt
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataApplication/AbstractDS_Aggregate_Type.xml.txt
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/AbstractObject_Type.xml">
+  <g:annotation>
+    <g:documentation>Identifiable collection of datasets</g:documentation>
+  </g:annotation>
+  <g:body>
+  
+    <!-- TODO recursion issues -->
+    <!--
+    <g:element g:targetName="gmd:composedOf" g:minOccurs="1" g:maxOccurs="unbounded"
+      g:label="$i18n.catalog.iso19139.AbstractDS_Aggregate.composedOf"
+      g:extends="$base/schema/gmd/metadataApplication/DS_DataSet_PropertyType.xml"/>
+    
+    <g:element g:targetName="gmd:seriesMetadata" g:minOccurs="1" g:maxOccurs="unbounded"
+      g:label="$i18n.catalog.iso19139.AbstractDS_Aggregate.seriesMetadata"
+      g:extends="$base/schema/gmd/metadataEntity/MD_Metadata_PropertyType.xml"/>
+      
+    <g:element g:targetName="gmd:subset" g:minOccurs="0" g:maxOccurs="unbounded"
+      g:label="$i18n.catalog.iso19139.AbstractDS_Aggregate.subset"
+      g:extends="$base/schema/gmd/metadataApplication/DS_Aggregate_PropertyType.xml"/>
+      
+    <g:element g:targetName="gmd:superset" g:minOccurs="0" g:maxOccurs="unbounded"
+      g:label="$i18n.catalog.iso19139.AbstractDS_Aggregate.superset"
+      g:extends="$base/schema/gmd/metadataApplication/DS_Aggregate_PropertyType.xml"/>
+    -->
+    
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataApplication/DS_Aggregate_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataApplication/DS_Aggregate_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" 
+      g:extends="$base/schema/gmd/metadataApplication/AbstractDS_Aggregate.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataApplication/DS_DataSet.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataApplication/DS_DataSet.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:DS_DataSet" 
+           g:extends="$base/schema/gmd/metadataApplication/DS_DataSet_Type.xml"> 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataApplication/DS_DataSet_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataApplication/DS_DataSet_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" 
+      g:extends="$base/schema/gmd/metadataApplication/DS_DataSet.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataApplication/DS_DataSet_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataApplication/DS_DataSet_Type.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.DS_DataSet" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/AbstractObject_Type.xml">
+  <g:annotation>
+    <g:documentation>Identifiable collection of data</g:documentation>
+  </g:annotation>
+  <g:body>
+  
+    <!-- TODO recursion issues -->
+    <!-- 
+    <g:element g:targetName="gmd:has" g:minOccurs="1" g:maxOccurs="unbounded"
+      g:extends="$base/schema/gmd/metadataEntity/MD_Metadata_PropertyType.xml"/>
+      
+    <g:element g:targetName="gmd:partOf" g:minOccurs="0" g:maxOccurs="unbounded"
+      g:extends="$base/schema/gmd/metadataApplication/DS_Aggregate_PropertyType.xml"/>
+    -->
+
+    
+
+    
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataApplication/DS_Initiative.xml.txt
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataApplication/DS_Initiative.xml.txt
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:DS_Platform" 
+           g:extends="$base/schema/gmd/metadataApplication/DS_Platform_Type.xml"> 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataApplication/DS_Initiative_PropertyType.xml.txt
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataApplication/DS_Initiative_PropertyType.xml.txt
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" 
+      g:extends="$base/schema/gmd/metadataApplication/DS_Initiative.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataApplication/DS_Initiative_Type.xml.txt
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataApplication/DS_Initiative_Type.xml.txt
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gmd/metadataApplication/AbstractDS_Aggregate_Type.xml"/>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataApplication/DS_OtherAggregate.xml.txt
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataApplication/DS_OtherAggregate.xml.txt
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:DS_OtherAggregate" 
+           g:extends="$base/schema/gmd/metadataApplication/DS_OtherAggregate_Type.xml"> 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataApplication/DS_OtherAggregate_PropertyType.xml.txt
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataApplication/DS_OtherAggregate_PropertyType.xml.txt
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" 
+      g:extends="$base/schema/gmd/metadataApplication/DS_OtherAggregate.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataApplication/DS_OtherAggregate_Type.xml.txt
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataApplication/DS_OtherAggregate_Type.xml.txt
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gmd/metadataApplication/AbstractDS_Aggregate_Type.xml"/>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataApplication/DS_Platform.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataApplication/DS_Platform.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:DS_Initiative" 
+           g:extends="$base/schema/gmd/metadataApplication/DS_Initiative_Type.xml"> 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataApplication/DS_Platform_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataApplication/DS_Platform_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" 
+      g:extends="$base/schema/gmd/metadataApplication/DS_Platform.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataApplication/DS_Platform_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataApplication/DS_Platform_Type.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gmd/metadataApplication/DS_Series_Type.xml"/>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataApplication/DS_ProductionSeries.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataApplication/DS_ProductionSeries.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:DS_ProductionSeries" 
+           g:extends="$base/schema/gmd/metadataApplication/DS_ProductionSeries_Type.xml"> 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataApplication/DS_ProductionSeries_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataApplication/DS_ProductionSeries_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" 
+      g:extends="$base/schema/gmd/metadataApplication/DS_ProductionSeries.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataApplication/DS_ProductionSeries_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataApplication/DS_ProductionSeries_Type.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gmd/metadataApplication/DS_Series_Type.xml"/>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataApplication/DS_Sensor.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataApplication/DS_Sensor.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:DS_Sensor" 
+           g:extends="$base/schema/gmd/metadataApplication/DS_Sensor_Type.xml"> 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataApplication/DS_Sensor_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataApplication/DS_Sensor_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" 
+      g:extends="$base/schema/gmd/metadataApplication/DS_Sensor.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataApplication/DS_Sensor_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataApplication/DS_Sensor_Type.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gmd/metadataApplication/DS_Series_Type.xml"/>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataApplication/DS_Series.xml.txt
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataApplication/DS_Series.xml.txt
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:DS_Series" 
+           g:extends="$base/schema/gmd/metadataApplication/DS_Series_Type.xml"> 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataApplication/DS_Series_PropertyType.xml.txt
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataApplication/DS_Series_PropertyType.xml.txt
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" 
+      g:extends="$base/schema/gmd/metadataApplication/DS_Series.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataApplication/DS_Series_Type.xml.txt
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataApplication/DS_Series_Type.xml.txt
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gmd/metadataApplication/AbstractDS_Aggregate_Type.xml"/>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataApplication/DS_StereoMate.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataApplication/DS_StereoMate.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:DS_StereoMate" 
+           g:extends="$base/schema/gmd/metadataApplication/DS_StereoMate_Type.xml"> 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataApplication/DS_StereoMate_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataApplication/DS_StereoMate_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" 
+      g:extends="$base/schema/gmd/metadataApplication/DS_StereoMate.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataApplication/DS_StereoMate_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataApplication/DS_StereoMate_Type.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gmd/metadataApplication/DS_OtherAggregate_Type.xml"/>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataEntity/MD_Metadata.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataEntity/MD_Metadata.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_Metadata" 
+           g:extends="$base/schema/gmd/metadataEntity/MD_Metadata_Type.xml"> 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataEntity/MD_Metadata_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataEntity/MD_Metadata_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gmd/metadataEntity/MD_Metadata.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataEntity/MD_Metadata_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataEntity/MD_Metadata_Type.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.MD_Metadata" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/AbstractObject_Type.xml">
+  <g:annotation>
+    <g:documentation>Information about the metadata</g:documentation>
+  </g:annotation>
+  <g:body>
+  
+    <g:element g:targetName="gmd:fileIdentifier" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+    
+    <g:element g:targetName="gmd:language" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+    
+    <g:element g:targetName="gmd:characterSet" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gmd/identification/MD_CharacterSetCode_PropertyType.xml"/>
+    
+    <g:element g:targetName="gmd:parentIdentifier" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+    
+    <g:element g:targetName="gmd:hierarchyLevel" g:minOccurs="0" g:maxOccurs="unbounded"
+      g:extends="$base/schema/gmd/maintenance/MD_ScopeCode_PropertyType.xml"/>
+      
+    <g:element g:targetName="gmd:hierarchyLevelName" g:minOccurs="0" g:maxOccurs="unbounded"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+      
+    <g:element g:targetName="gmd:contact" g:minOccurs="1" g:maxOccurs="unbounded"
+      g:extends="$base/schema/gmd/citation/CI_ResponsibleParty_PropertyType.xml"/>
+      
+    <g:element g:targetName="gmd:dateStamp" g:minOccurs="1" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/Date_PropertyType.xml"/>
+      
+    <g:element g:targetName="gmd:metadataStandardName" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+      
+    <g:element g:targetName="gmd:metadataStandardVersion" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+      
+    <g:element g:targetName="gmd:dataSetURI" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+      
+    <g:element g:targetName="gmd:locale" g:minOccurs="0" g:maxOccurs="unbounded"
+      g:extends="$base/schema/gmd/freeText/PT_Locale_PropertyType.xml"/>
+      
+    <g:element g:targetName="gmd:spatialRepresentationInfo" g:minOccurs="0" g:maxOccurs="unbounded"
+      g:extends="$base/schema/gmd/spatialRepresentation/MD_SpatialRepresentation_PropertyType.xml"/>
+
+    <g:element g:targetName="gmd:referenceSystemInfo" g:minOccurs="0" g:maxOccurs="unbounded"
+      g:extends="$base/schema/gmd/referenceSystem/MD_ReferenceSystem_PropertyType.xml"/>
+      
+    <g:element g:targetName="gmd:metadataExtensionInfo" g:minOccurs="0" g:maxOccurs="unbounded"
+      g:extends="$base/schema/gmd/metadataExtension/MD_MetadataExtensionInformation_PropertyType.xml"/>
+
+    <g:element g:targetName="gmd:identificationInfo" g:minOccurs="1" g:maxOccurs="unbounded"
+      g:extends="$base/schema/gmd/identification/MD_Identification_PropertyType.xml"/>
+
+    <g:element g:targetName="gmd:contentInfo" minOccurs="0" maxOccurs="unbounded"
+      g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">
+        <g:body>
+          <g:elementChoice g:minOccurs="0" g:extends="$base/xtn/ui/UI_ElementChoice.xml">
+            <g:body>
+              <g:import g:src="$base/schema/gmd/content/MD_FeatureCatalogueDescription.xml"/>
+              <g:import g:src="$base/schema/gmd/content/MD_CoverageDescription.xml"/>
+              <g:import g:src="$base/schema/gmd/content/MD_ImageDescription.xml"/>
+            </g:body>
+          </g:elementChoice>
+        </g:body>
+    </g:element>
+      
+    <g:element g:targetName="gmd:distributionInfo" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gmd/distribution/MD_Distribution_PropertyType.xml"/>
+      
+    <g:element g:targetName="gmd:dataQualityInfo" g:minOccurs="0" g:maxOccurs="unbounded"
+      g:extends="$base/schema/gmd/dataQuality/DQ_DataQuality_PropertyType.xml"/>
+      
+    <g:element g:targetName="gmd:portrayalCatalogueInfo" g:minOccurs="0" g:maxOccurs="unbounded"
+      g:extends="$base/schema/gmd/portrayalCatalogue/MD_PortrayalCatalogueReference_PropertyType.xml"/>
+
+    <g:element g:targetName="gmd:metadataConstraints" minOccurs="0" maxOccurs="unbounded"
+      g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">
+        <g:body>
+          <g:elementChoice g:minOccurs="0" g:extends="$base/xtn/ui/UI_ElementChoice.xml">
+            <g:body>
+              <g:import g:src="$base/schema/gmd/constraints/MD_Constraints.xml"/>
+              <g:import g:src="$base/schema/gmd/constraints/MD_LegalConstraints.xml"/>
+              <g:import g:src="$base/schema/gmd/constraints/MD_SecurityConstraints.xml"/>
+            </g:body>
+          </g:elementChoice>
+        </g:body>
+    </g:element>
+
+    <g:element g:targetName="gmd:applicationSchemaInfo" g:minOccurs="0" g:maxOccurs="unbounded"
+      g:extends="$base/schema/gmd/applicationSchema/MD_ApplicationSchemaInformation_PropertyType.xml"/>
+
+    <g:element g:targetName="gmd:metadataMaintenance" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gmd/maintenance/MD_MaintenanceInformation_PropertyType.xml"/>
+      
+    <g:element g:targetName="gmd:series" g:minOccurs="0" g:maxOccurs="unbounded"
+      g:extends="$base/schema/gmd/metadataApplication/DS_Aggregate_PropertyType.xml"/>
+      
+    <g:element g:targetName="gmd:describes" g:minOccurs="0" g:maxOccurs="unbounded"
+      g:extends="$base/schema/gmd/metadataApplication/DS_DataSet_PropertyType.xml"/>
+      
+    <g:element g:targetName="gmd:propertyType" g:minOccurs="0" g:maxOccurs="unbounded"
+      g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml"/>
+      
+    <g:element g:targetName="gmd:featureType" g:minOccurs="0" g:maxOccurs="unbounded"
+      g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml"/>
+      
+    <g:element g:targetName="gmd:featureAttribute" g:minOccurs="0" g:maxOccurs="unbounded"
+      g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml"/>
+    
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataExtension/MD_DatatypeCode.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataExtension/MD_DatatypeCode.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_DatatypeCode" 
+           g:i18nBase="catalog.iso19139.MD_DatatypeCode" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/CodeListValue_Type.xml">
+  <g:body>
+   
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeSpace.xml" 
+      g:value="ISOTC211/19115"/>
+       
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeList.xml"
+      g:value="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_DatatypeCode"/>
+     
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeListValue.xml">
+      <g:body>
+        <g:input g:extends="$base/core/ui/InputSelectOne.xml">
+          <g:options>
+            <g:option g:label="" g:value="" />
+            <g:option g:label="$i18nBase.class" g:value="class" />
+            <g:option g:label="$i18nBase.codelist" g:value="codelist" />
+            <g:option g:label="$i18nBase.enumeration" g:value="enumeration" />
+            <g:option g:label="$i18nBase.codelistElement" g:value="codelistElement" />
+            <g:option g:label="$i18nBase.abstractClass" g:value="abstractClass" />
+            <g:option g:label="$i18nBase.aggregateClass" g:value="aggregateClass" />
+            <g:option g:label="$i18nBase.specifiedClass" g:value="specifiedClass" />
+            <g:option g:label="$i18nBase.datatypeClass" g:value="datatypeClass" />
+            <g:option g:label="$i18nBase.interfaceClass" g:value="interfaceClass" />
+            <g:option g:label="$i18nBase.unionClass" g:value="unionClass" />
+            <g:option g:label="$i18nBase.metaClass" g:value="metaClass" />
+            <g:option g:label="$i18nBase.typeClass" g:value="typeClass" />
+            <g:option g:label="$i18nBase.characterString" g:value="characterString" />
+            <g:option g:label="$i18nBase.integer" g:value="integer" />
+            <g:option g:label="$i18nBase.association" g:value="association" />
+          </g:options>
+        </g:input>
+      </g:body>          
+    </g:attribute>     
+     
+  </g:body> 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataExtension/MD_DatatypeCode_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataExtension/MD_DatatypeCode_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/xtn/Wrapped_CodePropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" 
+      g:extends="$base/schema/gmd/metadataExtension/MD_DatatypeCode.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataExtension/MD_ExtendedElementInformation.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataExtension/MD_ExtendedElementInformation.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_ExtendedElementInformation" 
+           g:extends="$base/schema/gmd/metadataExtension/MD_ExtendedElementInformation_Type.xml"> 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataExtension/MD_ExtendedElementInformation_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataExtension/MD_ExtendedElementInformation_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" 
+      g:extends="$base/schema/gmd/metadataExtension/MD_ExtendedElementInformation.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataExtension/MD_ExtendedElementInformation_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataExtension/MD_ExtendedElementInformation_Type.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.MD_ExtendedElementInformation" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/AbstractObject_Type.xml">
+  <g:annotation>
+    <g:documentation>New metadata element, not found in ISO 19115, which is required to describe geographic data</g:documentation>
+  </g:annotation>
+  <g:body>
+  
+    <g:element g:targetName="gmd:name" g:minOccurs="1" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+      
+    <g:element g:targetName="gmd:shortName" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+      
+    <g:element g:targetName="gmd:domainCode" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/Integer_PropertyType.xml"/>
+      
+    <g:element g:targetName="gmd:definition" g:minOccurs="1" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+      
+    <g:element g:targetName="gmd:obligation" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gmd/metadataExtension/MD_ObligationCode_PropertyType.xml"/>
+
+    <g:element g:targetName="gmd:condition" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>    
+
+    <g:element g:targetName="gmd:dataType" g:minOccurs="1" g:maxOccurs="1"
+      g:extends="$base/schema/gmd/metadataExtension/MD_DatatypeCode_PropertyType.xml"/>    
+
+    <g:element g:targetName="gmd:maximumOccurrence" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>  
+
+    <g:element g:targetName="gmd:domainValue" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/> 
+
+    <g:element g:targetName="gmd:parentEntity" g:minOccurs="0" g:maxOccurs="unbounded"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/> 
+      
+    <g:element g:targetName="gmd:rule" g:minOccurs="1" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>       
+
+    <g:element g:targetName="gmd:rationale" g:minOccurs="0" g:maxOccurs="unbounded"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/> 
+      
+    <g:element g:targetName="gmd:source" g:minOccurs="0" g:maxOccurs="unbounded"
+      g:extends="$base/schema/gmd/citation/CI_ResponsibleParty_PropertyType.xml"/>
+
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataExtension/MD_MetadataExtensionInformation.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataExtension/MD_MetadataExtensionInformation.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_MetadataExtensionInformation" 
+           g:extends="$base/schema/gmd/metadataExtension/MD_MetadataExtensionInformation_Type.xml"> 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataExtension/MD_MetadataExtensionInformation_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataExtension/MD_MetadataExtensionInformation_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" 
+      g:extends="$base/schema/gmd/metadataExtension/MD_MetadataExtensionInformation.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataExtension/MD_MetadataExtensionInformation_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataExtension/MD_MetadataExtensionInformation_Type.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.MD_MetadataExtensionInformation" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/AbstractObject_Type.xml">
+  <g:annotation>
+    <g:documentation>Information describing metadata extensions.</g:documentation>
+  </g:annotation>
+  <g:body>
+  
+    <g:element g:targetName="gmd:extensionOnLineResource" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gmd/citation/CI_OnlineResource_PropertyType.xml"/>
+      
+    <g:element g:targetName="gmd:extendedElementInformation" g:minOccurs="0" g:maxOccurs="unbounded"
+      g:extends="$base/schema/gmd/metadataExtension/MD_ExtendedElementInformation_PropertyType.xml"/>
+    
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataExtension/MD_ObligationCode.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataExtension/MD_ObligationCode.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_ObligationCode" 
+           g:i18nBase="catalog.iso19139.MD_ObligationCode" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/CodeListValue_Type.xml">
+  <g:body>
+   
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeSpace.xml" 
+      g:value="ISOTC211/19115"/>
+       
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeList.xml"
+      g:value="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_ObligationCode"/>
+     
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeListValue.xml">
+      <g:body>
+        <g:input g:extends="$base/core/ui/InputSelectOne.xml">
+          <g:options>
+            <g:option g:label="" g:value="" />
+            <g:option g:label="$i18nBase.mandatory" g:value="mandatory" />
+            <g:option g:label="$i18nBase.optional" g:value="optional"/>
+            <g:option g:label="$i18nBase.conditional" g:value="conditional"/>
+          </g:options>
+        </g:input>
+      </g:body>          
+    </g:attribute>     
+     
+  </g:body> 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataExtension/MD_ObligationCode_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/metadataExtension/MD_ObligationCode_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/xtn/Wrapped_CodePropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" 
+      g:extends="$base/schema/gmd/metadataExtension/MD_ObligationCode.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/portrayalCatalogue/MD_PortrayalCatalogueReference.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/portrayalCatalogue/MD_PortrayalCatalogueReference.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_PortrayalCatalogueReference" 
+           g:extends="$base/schema/gmd/portrayalCatalogue/MD_PortrayalCatalogueReference_Type.xml"/>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/portrayalCatalogue/MD_PortrayalCatalogueReference_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/portrayalCatalogue/MD_PortrayalCatalogueReference_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" 
+      g:extends="$base/schema/gmd/portrayalCatalogue/MD_PortrayalCatalogueReference.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/portrayalCatalogue/MD_PortrayalCatalogueReference_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/portrayalCatalogue/MD_PortrayalCatalogueReference_Type.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.MD_PortrayalCatalogueReference" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/AbstractObject_Type.xml">
+  <g:annotation>
+    <g:documentation>Information identifing the portrayal catalogue used</g:documentation>
+  </g:annotation>
+  <g:body>
+  
+    <g:element g:targetName="gmd:portrayalCatalogueCitation" g:minOccurs="1" g:maxOccurs="unbounded"
+      g:extends="$base/schema/gmd/citation/CI_Citation_PropertyType.xml"/>
+    
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/referenceSystem/AbstractRS_ReferenceSystem.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/referenceSystem/AbstractRS_ReferenceSystem.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:AbstractRS_ReferenceSystem" 
+           g:extends="$base/schema/gmd/referenceSystem/AbstractRS_ReferenceSystem_Type.xml"> 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/referenceSystem/AbstractRS_ReferenceSystem_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/referenceSystem/AbstractRS_ReferenceSystem_Type.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/AbstractObject_Type.xml">
+  <g:annotation>
+    <g:documentation>Description of the spatial and temporal reference systems used in the dataset</g:documentation>
+  </g:annotation>
+  <g:body>
+  
+    <g:element g:targetName="gmd:name" g:minOccurs="1" g:maxOccurs="1"
+      g:label="$i18n.catalog.iso19139.AbstractRS_ReferenceSystem.name"
+      g:extends="$base/schema/gmd/referenceSystem/RS_Identifier_PropertyType.xml"/>
+    
+    <g:element g:targetName="gmd:domainOfValidity" g:minOccurs="0" g:maxOccurs="unbounded"
+      g:label="$i18n.catalog.iso19139.AbstractRS_ReferenceSystem.domainOfValidity"
+      g:extends="$base/schema/gmd/extent/EX_Extent_PropertyType.xml"/>
+    
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/referenceSystem/MD_Identifier.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/referenceSystem/MD_Identifier.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_Identifier" 
+           g:extends="$base/schema/gmd/referenceSystem/MD_Identifier_Type.xml"> 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/referenceSystem/MD_Identifier_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/referenceSystem/MD_Identifier_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" 
+      g:extends="$base/schema/gmd/referenceSystem/MD_Identifier.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/referenceSystem/MD_Identifier_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/referenceSystem/MD_Identifier_Type.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.MD_Identifier" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/AbstractObject_Type.xml">
+  <g:body>
+  
+    <!-- TODO recursion here when referenced from  CI_Citation_Type -->
+    <!-- 
+    <g:element g:targetName="gmd:authority" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gmd/citation/CI_Citation_PropertyType.xml"/>
+    -->
+    
+    <g:element g:targetName="gmd:code" g:minOccurs="1" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+    
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/referenceSystem/MD_ReferenceSystem.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/referenceSystem/MD_ReferenceSystem.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_ReferenceSystem" 
+           g:extends="$base/schema/gmd/referenceSystem/MD_ReferenceSystem_Type.xml"> 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/referenceSystem/MD_ReferenceSystem_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/referenceSystem/MD_ReferenceSystem_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" 
+      g:extends="$base/schema/gmd/referenceSystem/MD_ReferenceSystem.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/referenceSystem/MD_ReferenceSystem_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/referenceSystem/MD_ReferenceSystem_Type.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.MD_ReferenceSystem" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/AbstractObject_Type.xml">
+  <g:body>
+  
+    <g:element g:targetName="gmd:referenceSystemIdentifier" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gmd/referenceSystem/RS_Identifier_PropertyType.xml"/>
+    
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/referenceSystem/RS_Identifier.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/referenceSystem/RS_Identifier.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:RS_Identifier" 
+           g:extends="$base/schema/gmd/referenceSystem/RS_Identifier_Type.xml"> 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/referenceSystem/RS_Identifier_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/referenceSystem/RS_Identifier_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" 
+      g:extends="$base/schema/gmd/referenceSystem/RS_Identifier.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/referenceSystem/RS_Identifier_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/referenceSystem/RS_Identifier_Type.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.RS_Identifier" g:label="$i18nBase"
+           g:extends="$base/schema/gmd/referenceSystem/MD_Identifier_Type.xml">
+  <g:body>
+  
+    <g:element g:targetName="gmd:codeSpace" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+    
+    <g:element g:targetName="gmd:version" g:minOccurs="0" g:maxOccurs="1"
+      g:rendered="$editor.isAdvancedMode"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+    
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/referenceSystem/RS_ReferenceSystem_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/referenceSystem/RS_ReferenceSystem_PropertyType.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" 
+      g:extends="$base/schema/gmd/referenceSystem/AbstractRS_ReferenceSystem.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/AbstractMD_SpatialRepresentation.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/AbstractMD_SpatialRepresentation.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:AbstractMD_SpatialRepresentation" 
+           g:extends="$base/schema/gmd/spatialRepresentation/AbstractMD_SpatialRepresentation_Type.xml"> 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/AbstractMD_SpatialRepresentation_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/AbstractMD_SpatialRepresentation_Type.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/AbstractObject_Type.xml">
+  <g:annotation>
+    <g:documentation>Digital mechanism used to represent spatial information</g:documentation>
+  </g:annotation>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/MD_CellGeometryCode.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/MD_CellGeometryCode.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_CellGeometryCode" 
+           g:i18nBase="catalog.iso19139.MD_CellGeometryCode" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/CodeListValue_Type.xml">
+  <g:body>
+   
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeSpace.xml" 
+      g:value="ISOTC211/19115"/>
+       
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeList.xml"
+      g:value="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_CellGeometryCode"/>
+     
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeListValue.xml">
+      <g:body>
+        <g:input g:extends="$base/core/ui/InputSelectOne.xml">
+          <g:options>
+            <g:option g:label="" g:value="" />
+            <g:option g:label="$i18nBase.point" g:value="point" />
+            <g:option g:label="$i18nBase.area" g:value="area"/>
+          </g:options>
+        </g:input>
+      </g:body>          
+    </g:attribute>     
+     
+  </g:body> 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/MD_CellGeometryCode_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/MD_CellGeometryCode_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/xtn/Wrapped_CodePropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gmd/spatialRepresentation/MD_CellGeometryCode.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/MD_Dimension.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/MD_Dimension.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_Dimension" 
+           g:extends="$base/schema/gmd/spatialRepresentation/MD_Dimension_Type.xml"> 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/MD_DimensionNameTypeCode.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/MD_DimensionNameTypeCode.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_DimensionNameTypeCode" 
+           g:i18nBase="catalog.iso19139.MD_DimensionNameTypeCode" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/CodeListValue_Type.xml">
+  <g:body>
+   
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeSpace.xml" 
+      g:value="ISOTC211/19115"/>
+       
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeList.xml"
+      g:value="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_DimensionNameTypeCode"/>
+     
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeListValue.xml">
+      <g:body>
+        <g:input g:extends="$base/core/ui/InputSelectOne.xml">
+          <g:options>
+            <g:option g:label="" g:value="" />
+            <g:option g:label="$i18nBase.row" g:value="row" />
+            <g:option g:label="$i18nBase.column" g:value="column"/>
+            <g:option g:label="$i18nBase.vertical" g:value="vertical"/>
+            <g:option g:label="$i18nBase.track" g:value="track"/>
+            <g:option g:label="$i18nBase.crossTrack" g:value="crossTrack"/>
+            <g:option g:label="$i18nBase.line" g:value="line"/>
+            <g:option g:label="$i18nBase.sample" g:value="sample"/>
+            <g:option g:label="$i18nBase.time" g:value="time"/>
+          </g:options>
+        </g:input>
+      </g:body>          
+    </g:attribute>     
+     
+  </g:body> 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/MD_DimensionNameTypeCode_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/MD_DimensionNameTypeCode_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/xtn/Wrapped_CodePropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gmd/spatialRepresentation/MD_DimensionNameTypeCode.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/MD_Dimension_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/MD_Dimension_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gmd/spatialRepresentation/MD_Dimension.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/MD_Dimension_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/MD_Dimension_Type.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.MD_Dimension" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/AbstractObject_Type.xml">
+  <g:body>
+  
+    <g:element g:targetName="gmd:dimensionName" g:minOccurs="1" g:maxOccurs="1"
+      g:extends="$base/schema/gmd/spatialRepresentation/MD_DimensionNameTypeCode_PropertyType.xml"/>
+    
+    <g:element g:targetName="gmd:dimensionSize" g:minOccurs="1" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/Integer_PropertyType.xml"/>
+
+    <g:element g:targetName="gmd:resolution" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/Measure_PropertyType.xml"/>
+
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/MD_GeometricObjectTypeCode.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/MD_GeometricObjectTypeCode.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_GeometricObjectTypeCode" 
+           g:i18nBase="catalog.iso19139.MD_GeometricObjectTypeCode" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/CodeListValue_Type.xml">
+  <g:body>
+   
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeSpace.xml" 
+      g:value="ISOTC211/19115"/>
+       
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeList.xml"
+      g:value="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_GeometricObjectTypeCode"/>
+     
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeListValue.xml">
+      <g:body>
+        <g:input g:extends="$base/core/ui/InputSelectOne.xml">
+          <g:options>
+            <g:option g:label="" g:value="" />
+            <g:option g:label="$i18nBase.complex" g:value="complex" />
+            <g:option g:label="$i18nBase.composite" g:value="composite"/>
+            <g:option g:label="$i18nBase.curve" g:value="curve"/>
+            <g:option g:label="$i18nBase.point" g:value="point"/>
+            <g:option g:label="$i18nBase.solid" g:value="solid"/>
+            <g:option g:label="$i18nBase.surface" g:value="surface"/>
+          </g:options>
+        </g:input>
+      </g:body>          
+    </g:attribute>     
+     
+  </g:body> 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/MD_GeometricObjectTypeCode_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/MD_GeometricObjectTypeCode_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/xtn/Wrapped_CodePropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gmd/spatialRepresentation/MD_GeometricObjectTypeCode.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/MD_GeometricObjects.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/MD_GeometricObjects.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_GeometricObjects" 
+           g:extends="$base/schema/gmd/spatialRepresentation/MD_GeometricObjects_Type.xml"> 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/MD_GeometricObjects_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/MD_GeometricObjects_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gmd/spatialRepresentation/MD_GeometricObjects.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/MD_GeometricObjects_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/MD_GeometricObjects_Type.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.MD_GeometricObjects" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/AbstractObject_Type.xml">
+  <g:body>
+  
+    <g:element g:targetName="gmd:geometricObjectType" g:minOccurs="1" g:maxOccurs="1"
+      g:extends="$base/schema/gmd/spatialRepresentation/MD_GeometricObjectTypeCode_PropertyType.xml"/>
+    
+    <g:element g:targetName="gmd:geometricObjectCount" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/Integer_PropertyType.xml"/>
+    
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/MD_Georectified.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/MD_Georectified.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_Georectified" 
+           g:extends="$base/schema/gmd/spatialRepresentation/MD_Georectified_Type.xml"> 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/MD_Georectified_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/MD_Georectified_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gmd/spatialRepresentation/MD_Georectified.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/MD_Georectified_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/MD_Georectified_Type.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.MD_Georectified" g:label="$i18nBase"
+           g:extends="$base/schema/gmd/spatialRepresentation/MD_GridSpatialRepresentation_Type.xml">
+  <g:body>
+  
+    <g:element g:targetName="gmd:checkPointAvailability" g:minOccurs="1" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/Boolean_PropertyType.xml"/>
+    
+    <g:element g:targetName="gmd:checkPointDescription" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+
+    <!--  TODO requires implementation
+    <g:element g:targetName="gmd:cornerPoints" g:minOccurs="0" g:maxOccurs="unbounded"
+      g:extends="$base/gss/GM_Point_PropertyType.xml"/>
+    -->
+     
+    <!--  TODO requires implementation 
+    <g:element g:targetName="gmd:centerPoint" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/gss/GM_Point_PropertyType.xml"/>      
+    --> 
+    
+    <g:element g:targetName="gmd:pointInPixel" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gmd/spatialRepresentation/MD_PixelOrientationCode_PropertyType.xml"/>
+      
+    <g:element g:targetName="gmd:transformationDimensionDescription" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+      
+    <g:element g:targetName="gmd:transformationDimensionMapping" g:minOccurs="0" g:maxOccurs="2"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+    
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/MD_Georeferenceable.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/MD_Georeferenceable.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_Georeferenceable" 
+           g:extends="$base/schema/gmd/spatialRepresentation/MD_Georeferenceable_Type.xml"> 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/MD_Georeferenceable_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/MD_Georeferenceable_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gmd/spatialRepresentation/MD_Georeferenceable.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/MD_Georeferenceable_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/MD_Georeferenceable_Type.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.MD_Georeferenceable" g:label="$i18nBase"
+           g:extends="$base/schema/gmd/spatialRepresentation/MD_GridSpatialRepresentation_Type.xml">
+  <g:body>
+  
+    <g:element g:targetName="gmd:controlPointAvailability" g:minOccurs="1" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/Boolean_PropertyType.xml"/>
+
+    <g:element g:targetName="gmd:orientationParameterAvailability" g:minOccurs="1" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/Boolean_PropertyType.xml"/>      
+      
+    <g:element g:targetName="gmd:orientationParameterDescription" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/CharacterString_PropertyType.xml"/>
+      
+    <g:element g:targetName="gmd:georeferencedParameters" g:minOccurs="1" g:maxOccurs="1"
+      g:extends="$base/schema/gco/basicTypes/Record_PropertyType.xml"/>
+      
+    <g:element g:targetName="gmd:parameterCitation" g:minOccurs="0" g:maxOccurs="unbounded"
+      g:extends="$base/schema/gmd/citation/CI_Citation_PropertyType.xml"/>
+    
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/MD_GridSpatialRepresentation.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/MD_GridSpatialRepresentation.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_GridSpatialRepresentation" 
+           g:extends="$base/schema/gmd/spatialRepresentation/MD_GridSpatialRepresentation_Type.xml"> 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/MD_GridSpatialRepresentation_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/MD_GridSpatialRepresentation_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gmd/spatialRepresentation/MD_VectorSpatialRepresentation.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/MD_GridSpatialRepresentation_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/MD_GridSpatialRepresentation_Type.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.MD_GridSpatialRepresentation" g:label="$i18nBase"
+           g:extends="$base/schema/gmd/spatialRepresentation/AbstractMD_SpatialRepresentation_Type.xml">
+  <g:annotation>
+    <g:documentation>Types and numbers of raster spatial objects in the dataset</g:documentation>
+  </g:annotation>
+  <g:body>
+  
+    <g:element g:targetName="gmd:numberOfDimensions" g:minOccurs="1" g:maxOccurs="1"
+      g:label="$i18n.catalog.iso19139.MD_GridSpatialRepresentation.numberOfDimensions"
+      g:extends="$base/schema/gco/basicTypes/Integer_PropertyType.xml"/>
+    
+    <g:element g:targetName="gmd:axisDimensionProperties" g:minOccurs="0" g:maxOccurs="unbounded"
+      g:label="$i18n.catalog.iso19139.MD_GridSpatialRepresentation.axisDimensionProperties"
+      g:extends="$base/schema/gmd/spatialRepresentation/MD_Dimension_PropertyType.xml"/>
+
+    <g:element g:targetName="gmd:cellGeometry" g:minOccurs="1" g:maxOccurs="1"
+      g:label="$i18n.catalog.iso19139.MD_GridSpatialRepresentation.cellGeometry"
+      g:extends="$base/schema/gmd/spatialRepresentation/MD_CellGeometryCode_PropertyType.xml"/>
+      
+    <g:element g:targetName="gmd:transformationParameterAvailability" g:minOccurs="1" g:maxOccurs="1"
+      g:label="$i18n.catalog.iso19139.MD_GridSpatialRepresentation.transformationParameterAvailability"
+      g:extends="$base/schema/gco/basicTypes/Boolean_PropertyType.xml"/>
+
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/MD_PixelOrientationCode.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/MD_PixelOrientationCode.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_PixelOrientationCode" 
+           g:i18nBase="catalog.iso19139.MD_PixelOrientationCode" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/CodeListValue_Type.xml">
+  <g:body>
+   
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeSpace.xml" 
+      g:value="ISOTC211/19115"/>
+       
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeList.xml"
+      g:value="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_PixelOrientationCode"/>
+     
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeListValue.xml">
+      <g:body>
+        <g:input g:extends="$base/core/ui/InputSelectOne.xml">
+          <g:options>
+            <g:option g:label="" g:value="" />
+            <g:option g:label="$i18nBase.center" g:value="center" />
+            <g:option g:label="$i18nBase.lowerLeft" g:value="lowerLeft"/>
+            <g:option g:label="$i18nBase.lowerRight" g:value="lowerRight"/>
+            <g:option g:label="$i18nBase.upperRight" g:value="upperRight"/>
+            <g:option g:label="$i18nBase.upperLeft" g:value="upperLeft"/>
+          </g:options>
+        </g:input>
+      </g:body>          
+    </g:attribute>     
+     
+  </g:body> 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/MD_PixelOrientationCode_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/MD_PixelOrientationCode_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/xtn/Wrapped_CodePropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gmd/spatialRepresentation/MD_PixelOrientationCode.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/MD_SpatialRepresentation_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/MD_SpatialRepresentation_PropertyType.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+  
+    <!--
+    <g:element g:minOccurs="0" 
+      g:extends="$base/schema/gmd/spatialRepresentation/AbstractMD_SpatialRepresentation.xml"/>
+    -->
+  
+    <g:elementChoice g:minOccurs="0" g:extends="$base/xtn/ui/UI_ElementChoice.xml">
+      <g:body>
+	      <g:element g:extends="$base/schema/gmd/spatialRepresentation/MD_Georectified.xml"/>
+	      <g:element g:extends="$base/schema/gmd/spatialRepresentation/MD_Georeferenceable.xml"/>
+	      <g:element g:extends="$base/schema/gmd/spatialRepresentation/MD_GridSpatialRepresentation.xml"/>
+	      <g:element g:extends="$base/schema/gmd/spatialRepresentation/MD_VectorSpatialRepresentation.xml"/>
+      </g:body>
+    </g:elementChoice>
+
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/MD_TopologyLevelCode.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/MD_TopologyLevelCode.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_TopologyLevelCode" 
+           g:i18nBase="catalog.iso19139.MD_TopologyLevelCode" g:label="$i18nBase"
+           g:extends="$base/schema/gco/gcoBase/CodeListValue_Type.xml">
+  <g:body>
+   
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeSpace.xml" 
+      g:value="ISOTC211/19115"/>
+       
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeList.xml"
+      g:value="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_TopologyLevelCode"/>
+     
+    <g:attribute g:extends="$base/schema/gco/gcoBase/codeListValue.xml">
+      <g:body>
+        <g:input g:extends="$base/core/ui/InputSelectOne.xml">
+          <g:options>
+            <g:option g:label="" g:value="" />
+            <g:option g:label="$i18nBase.geometryOnly" g:value="geometryOnly" />
+            <g:option g:label="$i18nBase.topology1D" g:value="topology1D"/>
+            <g:option g:label="$i18nBase.planarGraph" g:value="planarGraph"/>
+            <g:option g:label="$i18nBase.fullPlanarGraph" g:value="fullPlanarGraph"/>
+            <g:option g:label="$i18nBase.surfaceGraph" g:value="surfaceGraph"/>
+            <g:option g:label="$i18nBase.fullSurfaceGraph" g:value="fullSurfaceGraph"/>
+            <g:option g:label="$i18nBase.topology3D" g:value="topology3D"/>
+            <g:option g:label="$i18nBase.fullTopology3D" g:value="fullTopology3D"/>
+            <g:option g:label="$i18nBase.abstract" g:value="abstract"/>
+          </g:options>
+        </g:input>
+      </g:body>          
+    </g:attribute>     
+     
+  </g:body> 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/MD_TopologyLevelCode_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/MD_TopologyLevelCode_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/xtn/Wrapped_CodePropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gmd/spatialRepresentation/MD_TopologyLevelCode.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/MD_VectorSpatialRepresentation.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/MD_VectorSpatialRepresentation.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:targetName="gmd:MD_VectorSpatialRepresentation" 
+           g:extends="$base/schema/gmd/spatialRepresentation/MD_VectorSpatialRepresentation_Type.xml"> 
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/MD_VectorSpatialRepresentation_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/MD_VectorSpatialRepresentation_PropertyType.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/schema/gco/gcoBase/ObjectReference_PropertyType.xml">       
+  <g:body>
+    <g:element g:minOccurs="0" g:extends="$base/schema/gmd/spatialRepresentation/MD_GridSpatialRepresentation.xml"/>
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/MD_VectorSpatialRepresentation_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/schema/gmd/spatialRepresentation/MD_VectorSpatialRepresentation_Type.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:i18nBase="catalog.iso19139.MD_VectorSpatialRepresentation" g:label="$i18nBase"
+           g:extends="$base/schema/gmd/spatialRepresentation/AbstractMD_SpatialRepresentation_Type.xml">
+  <g:annotation>
+    <g:documentation>Information about the vector spatial objects in the dataset</g:documentation>
+  </g:annotation>
+  <g:body>
+  
+    <g:element g:targetName="gmd:topologyLevel" g:minOccurs="0" g:maxOccurs="1"
+      g:extends="$base/schema/gmd/spatialRepresentation/MD_TopologyLevelCode_PropertyType.xml"/>
+    
+    <g:element g:targetName="gmd:geometricObjects" g:minOccurs="0" g:maxOccurs="unbounded"
+      g:extends="$base/schema/gmd/spatialRepresentation/MD_GeometricObjects_PropertyType.xml"/>
+
+  </g:body>
+</g:element>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/xtn/ui/UI_AbstractObject_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/xtn/ui/UI_AbstractObject_Type.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           h:class="gxeAbstractSection"
+           g:extends="$base/xtn/ui/UI_Element.xml">
+  <g:header g:rendered="$editor.isExpertMode"/> 
+  <g:body h:class="gxeAbstractSectionBody"/> 
+</g:element>
+

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/xtn/ui/UI_Attribute.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/xtn/ui/UI_Attribute.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/core/xml/Attribute.xml"/>
+

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/xtn/ui/UI_CodeListValue_Type.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/xtn/ui/UI_CodeListValue_Type.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           h:class="gxeWrappedCodeListValue"
+           g:extends="$base/xtn/ui/UI_Element.xml">
+  <g:header g:rendered="$editor.isExpertMode"/> 
+  <g:body h:class="gxeWrappedSectionBody"/>
+</g:element>
+

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/xtn/ui/UI_Code_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/xtn/ui/UI_Code_PropertyType.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/xtn/ui/UI_Element.xml">
+  <g:body h:class="gxeWrappedSectionBody"/> 
+</g:element>
+

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/xtn/ui/UI_Element.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/xtn/ui/UI_Element.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/core/xml/Element.xml"/>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/xtn/ui/UI_ElementChoice.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/xtn/ui/UI_ElementChoice.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:elementChoice xmlns:g="http://www.esri.com/geoportal/gxe" 
+                 xmlns:h="http://www.esri.com/geoportal/gxe/html"
+                 g:extends="$base/core/xml/ElementChoice.xml"/>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/xtn/ui/UI_ElementTextOnly.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/xtn/ui/UI_ElementTextOnly.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/xtn/ui/UI_Element.xml">
+  <g:body>
+    <g:input g:overridable="true" g:extends="$base/core/ui/InputText.xml"/>
+  </g:body> 
+</g:element>
+

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/xtn/ui/UI_Expert_Attribute.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/xtn/ui/UI_Expert_Attribute.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:rendered="$editor.isExpertMode"
+           g:extends="$base/xtn/ui/UI_Attribute.xml"/>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/xtn/ui/UI_ObjectReference_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/xtn/ui/UI_ObjectReference_PropertyType.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/xtn/ui/UI_Element.xml"/>
+

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/xtn/ui/UI_Tabs.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/xtn/ui/UI_Tabs.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:tabs xmlns:g="http://www.esri.com/geoportal/gxe" 
+        xmlns:h="http://www.esri.com/geoportal/gxe/html"
+        g:extends="$base/core/ui/Tabs.xml"/>

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/xtn/ui/UI_Wrapped_Basic_PropertyType.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/xtn/ui/UI_Wrapped_Basic_PropertyType.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           g:extends="$base/xtn/ui/UI_Element.xml">
+  <g:body h:class="gxeWrappedSectionBody"/>  
+</g:element>
+

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/xtn/ui/UI_Wrapped_Element.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/xtn/ui/UI_Wrapped_Element.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           h:class="gxeWrappedElement"
+           g:extensible="true" g:extends="$base/xtn/ui/UI_Element.xml">
+  <g:header g:rendered="$editor.isExpertMode"/> 
+</g:element>
+

--- a/geoportal/profiles/metadata/iso/iso19110/iso19110/xtn/ui/UI_Wrapped_ElementTextOnly.xml
+++ b/geoportal/profiles/metadata/iso/iso19110/iso19110/xtn/ui/UI_Wrapped_ElementTextOnly.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<g:element xmlns:g="http://www.esri.com/geoportal/gxe" 
+           xmlns:h="http://www.esri.com/geoportal/gxe/html"
+           h:class="gxeWrappedElement"
+           g:extensible="true" g:extends="$base/xtn/ui/UI_ElementTextOnly.xml">
+  <g:header g:rendered="$editor.isExpertMode"/> 
+</g:element>
+
+


### PR DESCRIPTION
Files to support creation, publish, and harvest of ISO 19110 Feature
Catalog metadata. Also creates metadata\iso subfolder in the "profiles"
folder for custom metadata profiles.
