### PR TITLE
Fixing missing start tag

### DIFF
--- a/geoportal/src/gpt/harvest/extract.xslt
+++ b/geoportal/src/gpt/harvest/extract.xslt
@@ -38,6 +38,7 @@ deleted=<number>
 <xsl:text>
 </xsl:text>
 <xsl:text>published=</xsl:text><xsl:call-template name="published"/>
+<xsl:text>
 </xsl:text>
 <xsl:text>deleted=</xsl:text><xsl:call-template name="deleted"/>
 </xsl:template>


### PR DESCRIPTION
Fix for a missing start tag in an XSL file.
