### PR TITLE
Modified XSL select condition in case gco:CharacterString is filled in a...

### DIFF
--- a/geoportal/src/gpt/search/profiles/CSW_2.0.2_APISO_GeoNetwork_GetRecords_Response.xslt
+++ b/geoportal/src/gpt/search/profiles/CSW_2.0.2_APISO_GeoNetwork_GetRecords_Response.xslt
@@ -70,7 +70,7 @@
 							</UpperCorner>
 
 							<xsl:for-each
-								select="./gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource[gmd:protocol/gco:CharacterString='OGC:WMS']/gmd:linkage/gmd:URL">
+								select="./gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource[gmd:protocol[contains(gco:CharacterString,'OGC:WMS')]]/gmd:linkage/gmd:URL">
 								<References>
 									<xsl:value-of select="." />
 									<xsl:text>&#x2714;</xsl:text>


### PR DESCRIPTION
... non-standard way:

gmd:protocol[contains(gco:CharacterString,'OGC:WMS')]

Example: Austria and Norway INSPIRE Geoportals have many WMS-services defined in a way where CharacterString equals "OGC:WMS-1.1.1-http-get-map".

Signed-off-by: Raivo Alla raivo.alla@maaamet.ee
