### PR TITLE
Update create_schema_mssql.cmd

### DIFF
--- a/geoportal/etc/sql/SQLServer/create_schema_mssql.cmd
+++ b/geoportal/etc/sql/SQLServer/create_schema_mssql.cmd
@@ -13,14 +13,14 @@ rem See the License for the specific language governing permissions and
 rem limitations under the License.
 
 @ECHO OFF
-IF "%1"=="" Goto Usage
+IF "%~1"=="" Goto Usage
 IF "%2"=="" Goto Usage
 IF "%3"=="" Goto Usage
 IF "%4"=="" Goto Usage
 
 
 
-SET DBSERVER=%1
+SET DBSERVER=%~1
 SET DATABASE=%2
 SET GEOPORTALUSERLOGIN=%3
 SET GEOPORTALUSERPWD=%4


### PR DESCRIPTION
Support for installing geoportal when SQL Server named instance is configured to use a fixed port:
http://msdn.microsoft.com/en-us/library/ms177440(v=sql.105).aspx

Wrap the first parameter in quotes and provide the custom port number with a comma.  
Sample Input: create_schema_mssql "mymachine,myport" geoportal geoportal geoportalpwd
