### PR TITLE
Duplicate metadata record

### DIFF
--- a/geoportal/src/com/esri/gpt/catalog/arcims/ImsMetadataAdminDao.java
+++ b/geoportal/src/com/esri/gpt/catalog/arcims/ImsMetadataAdminDao.java
@@ -1516,4 +1516,121 @@ private String uuidsToInClause(StringSet uuids) {
   return sb.toString();
 }
 
+/**
+ * Duplicate a record 
+ * 
+ * @param publisher the publisher executing this request
+ * @param uuids the set of uuids to update
+ * 
+ * The new record with following rules:
+ * - new UUID is random
+ * - new DOCUUID is random
+ * - new Title is Old Title + a timestamp
+ * - Same Owner
+ * - Status is set to draft
+ * - PubMethod is "editor"
+ */
+public int duplicateRecord(Publisher publisher, 
+        StringSet uuids)
+throws SQLException, CatalogIndexException {
+
+	// update the database approval status
+	PreparedStatement st = null;
+	PreparedStatement insRes = null;
+	PreparedStatement newIDst = null;
+	PreparedStatement insResData = null;
+	int nRows = 0;
+	Connection con = returnConnection().getJdbcConnection();
+	StringBuffer sbSql = new StringBuffer();
+	StringBuffer newDataID = new StringBuffer();
+	StringBuffer newResource = new StringBuffer();
+	StringBuffer newResourceData = new StringBuffer();
+
+	try {
+		String sUuids = uuidsToInClause(uuids);
+		if (sUuids.length() > 0) {   
+			// take the xml string of the selected record to duplicate from resource table
+			sbSql.append("SELECT XML,FILEIDENTIFIER,TITLE FROM "+this.getResourceDataTableName()+","+this.getResourceTableName());
+			sbSql.append(" WHERE "+this.getResourceDataTableName()+".DOCUUID="+this.getResourceTableName()+".DOCUUID AND "+this.getResourceDataTableName()+".DOCUUID IN (").append(sUuids).append(")");
+			logExpression(sbSql.toString());
+			LogUtil.getLogger().log(Level.INFO,sbSql.toString()+" "+sUuids);
+			st = con.prepareStatement(sbSql.toString());
+			ResultSet rs = st.executeQuery();
+			rs.next();
+			String xml=rs.getString(1);
+
+			String oldFileID=rs.getString(2);
+			String oldTitle=rs.getString(3);
+			closeStatement(st);
+
+			//create new resource record
+			Date d=new Date();
+			Timestamp t=new Timestamp(d.getTime());
+			
+			String newFileID="";
+			if((!oldFileID.equals(""))&&(!oldFileID.equals(" ")))
+				newFileID="{"+java.util.UUID.randomUUID().toString().toUpperCase()+"}";
+			LogUtil.getLogger().log(Level.INFO,oldFileID+";"+newFileID);
+			
+			String newTitle="";
+			if(oldTitle.contains(";-;"))
+				newTitle=oldTitle.substring(0,oldTitle.indexOf(";-;"))+";-;"+t;
+			else
+				newTitle=oldTitle+";-;"+t;
+			
+			String uuid = java.util.UUID.randomUUID().toString().toUpperCase();
+			newResource.append("INSERT INTO "+this.getResourceTableName()+" (DOCUUID,TITLE,OWNER,APPROVALSTATUS,PUBMETHOD,FILEIDENTIFIER) ");
+			newResource.append("VALUES (?,?,?,?,?,?)");
+			logExpression(newResource.toString());
+			LogUtil.getLogger().log(Level.INFO,newResource.toString()+" "+t+" "+uuid);
+			insRes=con.prepareStatement(newResource.toString());
+			insRes.setString(1, "{"+uuid+"}");
+			insRes.setString(2, newTitle);
+			insRes.setInt(3, publisher.getLocalID());
+			insRes.setString(4, "draft");
+			insRes.setString(5, "editor");
+			insRes.setString(6, newFileID);
+			nRows=insRes.executeUpdate();
+			closeStatement(insRes);
+
+			//take the ID just created for the new record
+			newDataID.append("SELECT ID FROM "+this.getResourceTableName());
+			newDataID.append(" WHERE DOCUUID IN (?)");
+			logExpression(newDataID.toString());
+			LogUtil.getLogger().log(Level.INFO,newDataID.toString()+" "+uuid);
+			newIDst = con.prepareStatement(newDataID.toString());
+			newIDst.setString(1, "{"+uuid+"}");
+			ResultSet IDset = newIDst.executeQuery();
+			IDset.next();
+			long ID=IDset.getLong(1);
+			closeStatement(newIDst);
+			
+			//insert the  new resource data record
+			String newXml="";
+			if(newFileID!="")
+				newXml=xml.replace(oldFileID,newFileID).replace(">"+oldTitle+"<",">"+newTitle+"<");//new fileID and title
+			else
+				newXml=xml.replace(">"+oldTitle+"<",">"+newTitle+"<");//new title
+			newResourceData.append("INSERT INTO "+this.getResourceDataTableName());
+			newResourceData.append(" (DOCUUID,ID,XML)");
+			newResourceData.append(" VALUES(?,?,?)");
+			logExpression(newResourceData.toString());
+			LogUtil.getLogger().log(Level.INFO,newResourceData.toString()+" "+uuid);
+			insResData=con.prepareStatement(newResourceData.toString());
+			insResData.setString(1, "{"+uuid+"}");
+			insResData.setLong(2, ID);
+			insResData.setString(3, newXml);
+			nRows=insResData.executeUpdate();
+			closeStatement(insResData);
+		}
+	} finally {
+	closeStatement(st);
+	closeStatement(insRes);
+	closeStatement(newIDst);
+	closeStatement(insResData);
+	}
+
+	return nRows;
+}
+
 }

--- a/geoportal/src/com/esri/gpt/catalog/management/MmdActionRequest.java
+++ b/geoportal/src/com/esri/gpt/catalog/management/MmdActionRequest.java
@@ -118,6 +118,8 @@ public void execute() throws Exception {
     nRows = adminDao.updateApprovalStatus(getPublisher(),uuids,MmdEnums.ApprovalStatus.disapproved);
   } else if (sAction.equalsIgnoreCase("setReviewed")) {
     nRows = adminDao.updateApprovalStatus(getPublisher(),uuids,MmdEnums.ApprovalStatus.reviewed);
+  } else if (sAction.equalsIgnoreCase("Duplicate")) {
+		nRows = adminDao.duplicateRecord(getPublisher(),uuids);
   }
   getActionResult().setNumberOfRecordsModified(nRows);
   this.hadUnalteredDraftDocuments = adminDao.hadUnalteredDraftDocuments();

--- a/geoportal/src/gpt/resources/gpt.properties
+++ b/geoportal/src/gpt/resources/gpt.properties
@@ -4276,3 +4276,7 @@ catalog.search.searchSite.dataGov.abstract = Search Data.gov
 catalog.search.searchSite.geoDab = GEO DAB
 catalog.search.searchSite.geoDab.abstract = Search GEO DAB
 catalog.search.resource.details.togglesection = Open/Close section
+
+# Duplicate
+catalog.publication.manageMetadata.action.Duplicate = Duplicate 
+catalog.publication.manageMetadata.action.Duplicate.err.tooManyRecords = For this operation you must select only one record

--- a/geoportal/www/catalog/publication/manageMetadataBody.jsp
+++ b/geoportal/www/catalog/publication/manageMetadataBody.jsp
@@ -114,6 +114,9 @@ function mmdOnActionButtonClicked() {
                      ).retrieveMessage("catalog.publication.manageMetadata.action.delete.confirm")%>";
   var sMsgApplyToAll = "<%=com.esri.gpt.framework.jsf.PageContext.extractMessageBroker(
                      ).retrieveMessage("catalog.publication.manageMetadata.action.applyToAll.confirm")%>";
+  // Error message fired when more than 1 record is selected for duplicating
+  var sMsgTooManyRecords = "<%=com.esri.gpt.framework.jsf.PageContext.extractMessageBroker(
+                     ).retrieveMessage("catalog.publication.manageMetadata.action.Duplicate.err.tooManyRecords")%>";
 
   var bContinue = false;
   var elForm = mmdFindForm();
@@ -157,6 +160,11 @@ function mmdOnActionButtonClicked() {
             if (sAction == "delete") {
               bContinue = confirm(sMsgDel);
             }
+		// Duplicate record: only one can be selected 
+		if((sAction=='duplicate')&&(sUuids.split(",").length > 1))
+		{	alert(sMsgTooManyRecords);
+			bContinue=false;
+		}            
           }
         }
     }
@@ -622,6 +630,10 @@ function mmdClearAclSelection(){
        itemValue="assignAcl"
        itemLabel="#{gptMsg['catalog.publication.manageMetadata.action.acl']}" 
        itemDisabled="#{ManageMetadataController.metadataAccessPolicyConfig.policyUnrestricted}"/>
+    <%// Duplicate command %>
+    <f:selectItem
+      itemValue="Duplicate"
+      itemLabel="#{gptMsg['catalog.publication.manageMetadata.action.Duplicate']}"/>       
   </h:selectOneMenu>
 
   <% // action to perform - administrator %>
@@ -649,6 +661,10 @@ function mmdClearAclSelection(){
     <f:selectItem
       itemValue="transfer"
       itemLabel="#{gptMsg['catalog.publication.manageMetadata.action.transfer']}"/>
+    <%// Duplicate command %>
+    <f:selectItem
+      itemValue="Duplicate"
+      itemLabel="#{gptMsg['catalog.publication.manageMetadata.action.Duplicate']}"/>            
     <f:selectItem
       itemValue="delete"
       itemLabel="#{gptMsg['catalog.publication.manageMetadata.action.delete']}"/>


### PR DESCRIPTION
This funcionality adds a "Duplicate" command in the action menu in Administartion Management page.This allows to duplicate a selected record, so that it can be used as a template when multiple, similar records must be edited.