### PR TITLE
Predefined extents

### DIFF
--- a/geoportal/src/com/esri/gpt/catalog/search/SearchFilterSpatial.java
+++ b/geoportal/src/com/esri/gpt/catalog/search/SearchFilterSpatial.java
@@ -18,6 +18,20 @@ import java.net.URL;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+/* Imports added to handle Bookmarks list */
+import java.util.ArrayList;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import com.esri.gpt.framework.collection.StringAttribute;
+import com.esri.gpt.framework.xml.DomUtil;
+import com.esri.gpt.framework.xml.NodeListAdapter;
+import javax.faces.model.SelectItem;
+import com.esri.gpt.framework.util.LogUtil;
+
 import com.esri.gpt.framework.geometry.Envelope;
 import com.esri.gpt.framework.util.Val;
 
@@ -69,6 +83,11 @@ private String _selectedBounds = OptionsBounds.anywhere.name();
 /** The envelope. */
 transient private Envelope _visibleEnvelope = new Envelope();
 
+/** Configuration for Bookmarks (predefined extents) **/
+private String _extent=new String();
+private ArrayList _predefinedExtents=new ArrayList();
+private static final String PREDEFINED_EXTENTS_FILE="gpt/config/extents.xml"; // NAME OF FILE IS HARDCODED
+
 // constructor =================================================================
 /**
  * Instantiates a new search filter spatial.
@@ -76,6 +95,59 @@ transient private Envelope _visibleEnvelope = new Envelope();
 public SearchFilterSpatial() { 
   super();
   reset();
+  
+// Load a fioel with predefined extents (bookmarks)
+  Document domFe;
+  XPath xpathFe;
+  try{
+	  String sPredefinedExtents = PREDEFINED_EXTENTS_FILE;
+	  LogUtil.getLogger().log(Level.FINE, "Loading Predefined extents file: {0}", sPredefinedExtents);
+	  domFe = DomUtil.makeDomFromResourcePath(sPredefinedExtents, false);
+	  xpathFe = XPathFactory.newInstance().newXPath();
+  }
+  catch(Exception e)
+  {
+	  LogUtil.getLogger().log(Level.FINE, "No predefined extents file");
+	  domFe=null;
+	  xpathFe=null;
+  }
+  // predefined extent file root
+  Node rootFe=null;
+  try{
+  if(domFe!=null)
+  	rootFe= (Node) xpathFe.evaluate("/extents", domFe, XPathConstants.NODE);
+  }
+  catch(Exception e)
+	{
+	  rootFe=null;
+	  LogUtil.getLogger().log(Level.FINE, "Xpath problem for predefined extents file");
+	}
+  /**
+   * Reads Bookmarks and load an array
+   */
+  NodeList extents;
+  ArrayList extentsList= new ArrayList();
+  if(rootFe!=null)
+  { try{
+	  extents=(NodeList)xpathFe.evaluate("extent", rootFe, XPathConstants.NODESET);
+	  for (Node extent : new NodeListAdapter(extents)) {
+		  String extPlace=(String) xpathFe.evaluate("@place", extent, XPathConstants.STRING);
+		  String extValue=(String) xpathFe.evaluate("@ext", extent, XPathConstants.STRING);
+		  LogUtil.getLogger().log(Level.FINE,"Element added:"+extPlace+","+extValue);
+		  SelectItem extElement=new SelectItem(extValue,extPlace);
+		  extentsList.add(extElement);
+	  }
+  	}
+	catch(Exception e)
+	{
+		extentsList=null;
+		LogUtil.getLogger().log(Level.FINE, "Xpath problem for predefined extents file");
+	}
+  }
+  else
+	  extentsList=null;
+  
+  this._predefinedExtents=extentsList;
 }
 
 // properties ==================================================================
@@ -336,6 +408,35 @@ public Envelope getEnvelope() {
 public void setEnvelope(Envelope envelope) {
   this.setSelectedEnvelope(envelope);
   
+}
+
+/* Added functions to handle predefined extents
+/**
+ * @param _extent the extent to set
+ */
+public void setExtent(String extent) {
+	this._extent = extent;
+}
+
+/**
+ * @return the _extent
+ */
+public String getExtent() {
+	return _extent;
+}
+
+/**
+ * @param _predefinedExtents the _predefinedExtents to set
+*/ 
+public void setPredefinedExtents(ArrayList predefinedExtents) {
+	this._predefinedExtents = _predefinedExtents;
+}
+
+/**
+ * @return the _predefinedExtents
+ */
+public ArrayList getPredefinedExtents() {
+	return _predefinedExtents;
 }
 
 }

--- a/geoportal/src/gpt/config/extents.xml
+++ b/geoportal/src/gpt/config/extents.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extents>
+	<extent place="Piemonte"  ext="6.62;44.06;9.22;46.47"/>
+	<extent place="Valle d'Aosta/Vallée d'Aoste"  ext="6.8;45.46;7.94;45.99"/>
+	<extent place="Lombardia"  ext="8.49;44.67;11.43;46.64"/>
+	<extent place="Trentino-Alto Adige"  ext="10.38;45.67;12.48;47.1"/>
+	<extent place="Veneto"  ext="10.62;44.79;13.11;46.69"/>
+	<extent place="Friuli-Venezia Giulia"  ext="12.32;45.58;13.92;46.65"/>
+	<extent place="Liguria"  ext="7.49;43.77;10.08;44.68"/>
+	<extent place="Emilia-Romagna"  ext="9.19;43.73;12.76;45.14"/>
+	<extent place="Toscana"  ext="9.68;42.23;12.38;44.48"/>
+	<extent place="Umbria"  ext="11.89;42.36;13.27;43.62"/>
+	<extent place="Marche"  ext="12.18;42.68;13.92;43.97"/>
+	<extent place="Lazio"  ext="11.44;40.78;14.03;42.84"/>
+	<extent place="Abruzzo"  ext="13.01;41.68;14.79;42.9"/>
+	<extent place="Molise"  ext="13.94;41.36;15.17;42.07"/>
+	<extent place="Campania"  ext="13.76;39.99;15.81;41.51"/>
+	<extent place="Puglia"  ext="14.93;39.79;18.53;42.23"/>
+	<extent place="Basilicata"  ext="15.33;39.89;16.87;41.14"/>
+	<extent place="Calabria"  ext="15.63;37.91;17.21;40.15"/>
+	<extent place="Sicilia"  ext="11.92;35.49;15.66;38.82"/>
+	<extent place="Sardegna"  ext="8.13;38.85;9.83;41.32"/>
+</extents>

--- a/geoportal/src/gpt/resources/gpt.properties
+++ b/geoportal/src/gpt/resources/gpt.properties
@@ -4276,3 +4276,7 @@ catalog.search.searchSite.dataGov.abstract = Search Data.gov
 catalog.search.searchSite.geoDab = GEO DAB
 catalog.search.searchSite.geoDab.abstract = Search GEO DAB
 catalog.search.resource.details.togglesection = Open/Close section
+
+# Bookmarks (predefined extents) 
+catalog.search.filterSpatial.extents = Select a bookmark
+catalog.search.filterSpatial.extents.default = Default

--- a/geoportal/www/catalog/search/criteria.jsp
+++ b/geoportal/www/catalog/search/criteria.jsp
@@ -1766,6 +1766,16 @@
   <% // map %>
   <h:panelGrid id="pnlMap">
     <h:panelGroup id="mapToolbar" styleClass="mapToolbar" style="display:none">
+      <% // List of predefined extents %>
+      <h:selectOneMenu id="scSel"
+                     value="#{SearchController.searchCriteria.searchFilterSpatial.extent}"
+                     onchange="javascript: setMapExtent();"
+                     >
+	  <f:selectItem itemValue="" itemLabel="#{gptMsg['catalog.search.filterSpatial.extents']}"/>
+	  <f:selectItem itemValue="default" itemLabel="#{gptMsg['catalog.search.filterSpatial.extents.default']}"/>
+          <f:selectItems value="#{SearchController.searchCriteria.searchFilterSpatial.predefinedExtents}"/>
+      </h:selectOneMenu>
+      <h:outputText id="brksc" escape="false" value="<br/>"/>
       <h:outputLabel for="mapInput-locate" value="#{gptMsg['catalog.search.search.lblLocator']}"/>
       <h:inputText id="mapInput-locate" styleClass="locatorInput"
                    maxlength="1024" onkeypress="return scMap.onLocatorKeyPress(event);"/>

--- a/geoportal/www/catalog/search/searchBody.jsp
+++ b/geoportal/www/catalog/search/searchBody.jsp
@@ -39,6 +39,20 @@
   
   var _frmDjSearchCriteria = null;
   
+   	// Set the extent based on the bookmark selected. WARNING: the WKID is hardcoded to 4326.
+    	function setMapExtent()
+	{	var extent= document.getElementById("frmSearchCriteria:scSel").value;
+	    	if((extent!=null)&&(extent!=""))
+		{
+			if(extent=="default")
+				selectedExtent= eval("new esri.geometry.Extent({"+gptMapConfig.mapInitialExtent+"})");
+			else
+				var selectedExtent = new esri.geometry.Extent(Number(extent.split(";")[0]),Number(extent.split(";")[1]),Number(extent.split(";")[2]),Number(extent.split(";")[3]),(new esri.SpatialReference({wkid:4326})));
+
+			scMap._gptMap.zoom(selectedExtent);
+		}
+	}
+	
   function serilizeFormToCookie() {
     //dojo.cookie(_cookieLabel, dojo.formToJson("frmSearchCriteria"));
   }
@@ -113,6 +127,18 @@ dojo.declare("SearchMap", null, {
     
   },
 
+	setMapExtent:function() // Set map extent based on bookmark
+	{	var extent= document.getElementById("frmSearchCriteria:scSel").value;
+	    if((extent!=null)&&(extent!=""))
+		{	if(extent=="default")
+				selectedExtent= eval("new esri.geometry.Extent({"+gptMapConfig.mapInitialExtent+"})");
+			else
+				var selectedExtent = new esri.geometry.Extent(Number(extent.split(";")[0]),Number(extent.split(";")[1]),Number(extent.split(";")[2]),Number(extent.split(";")[3]),(new esri.SpatialReference({wkid:4326})));
+			
+			scMap._gptMap.zoom(selectedExtent);
+		}
+	},
+
   initialize: function() {
     var config = gptMapConfig;
 
@@ -149,8 +175,13 @@ dojo.declare("SearchMap", null, {
   },
 
   onMapLoaded: function() {
-    if (this._gptMap!=null) {      
-      setTimeout(dojo.hitch(this,"zoomToInitExtent",true),1000);
+    if (this._gptMap!=null) {
+	// Set the map extent based on the bookmark
+    	var extent= document.getElementById("frmSearchCriteria:scSel").value;
+	if((extent!=null)&&(extent!=""))
+		setTimeout(dojo.hitch(this,"setMapExtent",true),1000);
+	else
+      		setTimeout(dojo.hitch(this,"zoomToInitExtent",true),1000);
       this.drawFootPrints();
       var agsMap = this._gptMap.getAgsMap();
       if (agsMap != null) {


### PR DESCRIPTION
This patch addes a listbox in the search page where bookmarks (predefined extents) are loaded. The user can choose on of the bookmarks to quickly pan on the map. The extents are loaded from an xml file.
There are some possibile enhancements that can be done:
- the name of the file is hardcoded (gpt/config/extents.xml)
- the WKID is hardcoded (4326)
Example of this funciont can be seen in:
http://www.geoportale.isprambiente.it/geoportale/catalog/main/home.page