### PR TITLE
Administrator can always edit

### DIFF
--- a/geoportal/src/com/esri/gpt/control/publication/EditMetadataController.java
+++ b/geoportal/src/com/esri/gpt/control/publication/EditMetadataController.java
@@ -372,8 +372,11 @@ private void executeOpen(ActionEvent event, RequestContext context)
     
   // prepare the publisher
   getSelectablePublishers().setSelectedKey(getOnBehalfOf());
-  Publisher publisher = getSelectablePublishers().selectedAsPublisher(context,false);
-  
+
+  // Modified by Esri Italy: set to true to overcome control on owner/publisher useful for enableEditForAdministrator flag
+  // Publisher publisher = getSelectablePublishers().selectedAsPublisher(context,false);
+  Publisher publisher = getSelectablePublishers().selectedAsPublisher(context,true);
+
   // prepare the schema for edit
   MetadataDocument document = new MetadataDocument();
   Schema schema = document.prepareForEdit(context,publisher,sOpenDocumentUuid);

--- a/geoportal/src/com/esri/gpt/control/publication/EditMetadataController.java
+++ b/geoportal/src/com/esri/gpt/control/publication/EditMetadataController.java
@@ -526,8 +526,9 @@ private void executeSave(ActionEvent event,
   
   // prepare the publisher
   getSelectablePublishers().setSelectedKey(getOnBehalfOf());
-  Publisher publisher = getSelectablePublishers().selectedAsPublisher(context,false);
-
+  // Modified by Esri Italy: set to true to overcome control on owner/publisher useful for enableEditForAdministrator flag
+  // Publisher publisher = getSelectablePublishers().selectedAsPublisher(context,false);
+  Publisher publisher = getSelectablePublishers().selectedAsPublisher(context,true);
   //  the document
   
   if (validateOnly) {

--- a/geoportal/src/gpt/config/gpt.xml
+++ b/geoportal/src/gpt/config/gpt.xml
@@ -366,6 +366,8 @@
 				Default: false.                  
         -->  
         <parameter key="catalog.enableEditForAllPubMethods" value="false"/>
+	<!-- This flag allows an administrator to modify metadata records even if he's not the owner -->
+	<parameter key="catalog.enableEditForAdministrator" value="true"/>
         <parameter key="catalog.admin.allowApplyToAll" value="true"/>
         <parameter key="catalog.useCollections" value="false"/>
         <parameter key="database.isCaseSensitive" value="true"/>


### PR DESCRIPTION
This enhancement adds a flag in gpt.xml:
```
		<parameter key="catalog.enableEditForAdministrator" value="true"/>
```
that when set to true allows an Administrator to edit metadata records even if he not the owner.
If the parameter is false or is not present than the default behaviour is set.