### PR TITLE
Allow only authenticated users

### DIFF
--- a/geoportal/src/gpt/config/gpt.xml
+++ b/geoportal/src/gpt/config/gpt.xml
@@ -378,7 +378,8 @@
         <parameter key="httpClientRequest.connectionTimeout" value="2[MINUTE]"/>
         <parameter key="httpClientRequest.responseTimeout" value="2[MINUTE]"/>
         <parameter key="httpClient.alwaysClose" value="false"/>
-  
+	<!-- Setting AllowonlyAuthenticatedUser to true denies access to anonymous users. -->
+	<parameter key="AllowOnlyAuthenticatedUser" value="true"/>	  
         
 		    <!-- Resource Link Builder
 			      - resourceLinkBuilder.preview.filter: regular expression disabling ‘preview’ link on search result 

--- a/geoportal/www/catalog/main/homeBody.jsp
+++ b/geoportal/www/catalog/main/homeBody.jsp
@@ -97,6 +97,10 @@ function hpSubmitForm(event, form) {
 
 			<h:panelGrid columns="1" summary="#{gptMsg['catalog.general.designOnly']}" width="90%" styleClass="homeTableCol">
 				<h:panelGrid columns="2" id="_pnlKeyword" cellpadding="0" cellspacing="0">
+				   <%// Handle the AllowOnlyAutheticatedUser parameter: if set to true authentication is mandatory
+				   com.esri.gpt.framework.context.RequestContext rcx = com.esri.gpt.framework.context.RequestContext.extract(request);
+				   String sAllowOnlyAuthenticatedUser=rcx.getApplicationConfiguration().getCatalogConfiguration().getParameters().getValue("AllowOnlyAuthenticatedUser");
+				   if (!sAllowOnlyAuthenticatedUser.equals("true") || (rcx.getUser().getAuthenticationStatus().getWasAuthenticated())) {%>
 				
 					<h:form id="hpFrmSearch" onkeypress="javascript: hpSubmitForm(event, this);">
 					<h:inputText id="itxFilterKeywordText" 
@@ -112,7 +116,7 @@ function hpSubmitForm(event, form) {
 					    value="#{SearchController.searchEvent.eventExecuteSearch}" />
 					</h:commandButton>
 					</h:form>
-					
+				   <%}%>			
 				</h:panelGrid>
 
 				<h:outputText value="#{gptMsg['catalog.main.home.topic.findData.searchData']}"/>

--- a/geoportal/www/catalog/search/browse/browse.jsp
+++ b/geoportal/www/catalog/search/browse/browse.jsp
@@ -13,6 +13,15 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 --%>
+<%
+// If parameter is set then authentication is mandatory
+com.esri.gpt.framework.context.RequestContext rcx = com.esri.gpt.framework.context.RequestContext.extract(request);
+String sAllowOnlyAuthenticatedUser=rcx.getApplicationConfiguration().getCatalogConfiguration().getParameters().getValue("AllowOnlyAuthenticatedUser");
+if (sAllowOnlyAuthenticatedUser.equals("true")&&(!rcx.getUser().getAuthenticationStatus().getWasAuthenticated())) {
+response.sendRedirect(request.getContextPath() + "/catalog/identity/login.page");
+}
+%>
+
 <% // browse.jsp - Browse page (tiles definition) %>
 <%@taglib uri="http://struts.apache.org/tags-tiles" prefix="tiles" %>
 <%@taglib uri="http://www.esri.com/tags-gpt" prefix="gpt" %>

--- a/geoportal/www/catalog/search/search.jsp
+++ b/geoportal/www/catalog/search/search.jsp
@@ -13,6 +13,15 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 --%>
+<% 
+// If parameter is set then authentication is mandatory
+ com.esri.gpt.framework.context.RequestContext rcx = com.esri.gpt.framework.context.RequestContext.extract(request);
+ String sAllowOnlyAuthenticatedUser=rcx.getApplicationConfiguration().getCatalogConfiguration().getParameters().getValue("AllowOnlyAuthenticatedUser");
+ if (sAllowOnlyAuthenticatedUser.equals("true")&&(!rcx.getUser().getAuthenticationStatus().getWasAuthenticated())) {
+		 response.sendRedirect(request.getContextPath() + "/catalog/identity/login.page");
+	}
+%>
+
  <% // search.jsp - Search page(tiles definition) %>
 <%@taglib prefix="tiles" uri="http://struts.apache.org/tags-tiles"%>
 <%@taglib prefix="gpt" uri="http://www.esri.com/tags-gpt"%>

--- a/geoportal/www/catalog/skins/tiles/primaryNavigation.jsp
+++ b/geoportal/www/catalog/skins/tiles/primaryNavigation.jsp
@@ -15,8 +15,8 @@
 --%>
 <%@taglib prefix="f" uri="http://java.sun.com/jsf/core"%>
 <%@taglib prefix="h" uri="http://java.sun.com/jsf/html"%>
-<%@taglib prefix="tiles" uri="http://struts.apache.org/tags-tiles"  %>
 
+<%@taglib prefix="tiles" uri="http://struts.apache.org/tags-tiles"  %>
 <h:form id="frmBanner">	
 	<h:outputLink 
 	  rendered="#{not empty PageContext.applicationConfiguration.catalogConfiguration.searchConfig.mapViewerUrl}"
@@ -33,25 +33,54 @@
   </h:outputLink>
 </h:form>
 
+<%--Modified to handle the AllowOnlyAuthenticatedUser parameter. If set to true (default is false), then login is required for all users --%>
 <h:form id="frmPrimaryNavigation">
 	<h:commandLink
         id="mainHome" 
         action="catalog.main.home"
         value="#{gptMsg['catalog.main.home.menuCaption']}"
         styleClass="#{PageContext.tabStyleMap['catalog.main.home']}"/>
-	<h:commandLink 
-        id="searchHome" 
-        action="catalog.search.home" 
-        value="#{gptMsg['catalog.search.home.menuCaption']}"
-        styleClass="#{PageContext.tabStyleMap['catalog.search.home']}"/>                 
 
-  <h:commandLink 
-        id="browse"
-        action="catalog.browse" 
-        styleClass="#{PageContext.tabStyleMap['catalog.browse']}"
-        value="#{gptMsg['catalog.browse.menuCaption']}"
-        rendered="#{PageContext.tocsByKey['browseCatalog']}" />
- 
+	<%
+	com.esri.gpt.framework.context.RequestContext rcx = com.esri.gpt.framework.context.RequestContext.extract(request);
+	String sAllowOnlyAuthenticatedUser=rcx.getApplicationConfiguration().getCatalogConfiguration().getParameters().getValue("AllowOnlyAuthenticatedUser");
+	if(sAllowOnlyAuthenticatedUser.equals("true"))
+	{
+	%>        
+		<h:commandLink 
+	        id="searchHome"
+	        rendered="#{PageContext.roleMap['gptRegisteredUser']}"
+	        action="catalog.search.home" 
+	        value="#{gptMsg['catalog.search.home.menuCaption']}"
+	        styleClass="#{PageContext.tabStyleMap['catalog.search.home']}"/>                 
+
+		<h:commandLink 
+		id="browse"
+		action="catalog.browse" 
+		styleClass="#{PageContext.tabStyleMap['catalog.browse']}"
+		value="#{gptMsg['catalog.browse.menuCaption']}"
+        	rendered="#{PageContext.tocsByKey['browseCatalog'] and PageContext.roleMap['gptRegisteredUser']}" />			
+	<%
+	}
+	else
+	{
+	%>
+		<h:commandLink 
+	        id="searchHome" 
+	        action="catalog.search.home" 
+	        value="#{gptMsg['catalog.search.home.menuCaption']}"
+	        styleClass="#{PageContext.tabStyleMap['catalog.search.home']}"/>                 
+
+		<h:commandLink 
+		id="browse"
+		action="catalog.browse" 
+		styleClass="#{PageContext.tabStyleMap['catalog.browse']}"
+		value="#{gptMsg['catalog.browse.menuCaption']}"
+		rendered="#{PageContext.tocsByKey['browseCatalog']}" />
+	<%
+	}
+	%>
+	
   <h:commandLink 
         id="publicationManageMetadata"
         action="catalog.publication.manageMetadata" 


### PR DESCRIPTION
Defines a config parameter in gpt.xml that, if set to true, denies search to anonymous users (i.e. login is required). 
```
		<parameter key="AllowOnlyAuthenticatedUser" value="true"/>
```
With these modifications the Home page will not have the Search and Browse menus; this page should be substituted with a help or startup page. Direct access to Search and Browse is also controlled (catalog/main/search/search.page and catalog/main/search/browse/browse.page). Detail page as well as CSW endpoint are NOT controlled; a correct GetRecords request will be honoured: to avoid so some additional control (for example URL mapping rules)  must be implemented.