### PR TITLE
Make record editable

### DIFF
--- a/geoportal/src/com/esri/gpt/catalog/arcims/ImsMetadataAdminDao.java
+++ b/geoportal/src/com/esri/gpt/catalog/arcims/ImsMetadataAdminDao.java
@@ -1480,6 +1480,42 @@ public void deleteIndex(PublicationRecord record)
 }
 
 /**
+ * Makes the selected records editable, changing the
+ * publication method in "editor"
+ * 
+ * @param publisher the publisher executing this request
+ * @param uuids the set of uuids to update
+ */
+public int setEditable(Publisher publisher, 
+        StringSet uuids)
+throws SQLException, CatalogIndexException {
+
+// update the database publication method
+PreparedStatement st = null;
+int nRows = 0;
+Connection con = returnConnection().getJdbcConnection();
+StringBuffer sbSql = new StringBuffer();
+try {
+	String sUuids = uuidsToInClause(uuids);
+	if (sUuids.length() > 0) {   
+		// execute the update, don't update documents in 'draft' mode
+		sbSql = new StringBuffer();     
+		sbSql.append("UPDATE ").append(getResourceTableName());
+		sbSql.append(" SET PUBMETHOD='editor'");
+		sbSql.append(" WHERE DOCUUID IN (").append(sUuids).append(")");
+		logExpression(sbSql.toString());
+		LogUtil.getLogger().log(Level.INFO,sbSql.toString()+" "+sUuids);
+		st = con.prepareStatement(sbSql.toString());
+		nRows = st.executeUpdate();
+	}
+} finally {
+closeStatement(st);
+}
+
+return nRows;
+}
+
+/**
  * Updates the synchronization status code for a collection of records.
  * @param status the synchronization status code
  * @param where the where clause indicating the recouds to update

--- a/geoportal/src/com/esri/gpt/catalog/management/MmdActionRequest.java
+++ b/geoportal/src/com/esri/gpt/catalog/management/MmdActionRequest.java
@@ -119,6 +119,11 @@ public void execute() throws Exception {
   } else if (sAction.equalsIgnoreCase("setReviewed")) {
     nRows = adminDao.updateApprovalStatus(getPublisher(),uuids,MmdEnums.ApprovalStatus.reviewed);
   }
+  /** Action: "SetEditable" **/
+  else if (sAction.equalsIgnoreCase("setEditable")) {
+		nRows = adminDao.setEditable(getPublisher(),uuids);
+  }
+
   getActionResult().setNumberOfRecordsModified(nRows);
   this.hadUnalteredDraftDocuments = adminDao.hadUnalteredDraftDocuments();
 

--- a/geoportal/src/gpt/resources/gpt.properties
+++ b/geoportal/src/gpt/resources/gpt.properties
@@ -4276,3 +4276,6 @@ catalog.search.searchSite.dataGov.abstract = Search Data.gov
 catalog.search.searchSite.geoDab = GEO DAB
 catalog.search.searchSite.geoDab.abstract = Search GEO DAB
 catalog.search.resource.details.togglesection = Open/Close section
+
+// Action setEditable
+catalog.publication.manageMetadata.action.setEditable= Set as Editable

--- a/geoportal/www/catalog/publication/manageMetadataBody.jsp
+++ b/geoportal/www/catalog/publication/manageMetadataBody.jsp
@@ -649,6 +649,10 @@ function mmdClearAclSelection(){
     <f:selectItem
       itemValue="transfer"
       itemLabel="#{gptMsg['catalog.publication.manageMetadata.action.transfer']}"/>
+    <%// SetEditable commands%>
+    <f:selectItem
+      itemValue="setEditable"
+      itemLabel="#{gptMsg['catalog.publication.manageMetadata.action.setEditable']}"/>
     <f:selectItem
       itemValue="delete"
       itemLabel="#{gptMsg['catalog.publication.manageMetadata.action.delete']}"/>


### PR DESCRIPTION
It adds the new action setEditable to the list of actions in Administration page. The user can select one or more records and set them editable even if they come from another repository; this allows to handle editability of single records while the catalog.enableEditForAllPubMethods parameter of gpt.xml applies to all records.  The function changes the publication method of each selected record, setting it to "editor" as if it was created with the geoportal's editor. A useful enhancement would be to separate the pubmethod from the editable property by adding another flag in the database and use this for editable property of a record.