### PR TITLE
Allow duplicate resource url

### DIFF
--- a/geoportal/src/com/esri/gpt/catalog/harvest/repository/HrAssertUrlRequest.java
+++ b/geoportal/src/com/esri/gpt/catalog/harvest/repository/HrAssertUrlRequest.java
@@ -74,7 +74,12 @@ public class HrAssertUrlRequest extends HrRequest {
 
       rs = st.executeQuery();
 
-      return rs.next();
+       /* if "AllowDuplicateResourceURL" exists and is "true", then it is possibile to register web resources with same url */
+      if ((getRequestContext().getCatalogConfiguration().getParameters().containsKey("AllowDuplicateResourceURL")) &&
+	          (getRequestContext().getCatalogConfiguration().getParameters().getValue("AllowDuplicateResourceURL").equals("true")) )
+          return(false); 
+      else
+	        return rs.next();
 
     } finally {
       closeResultSet(rs);

--- a/geoportal/src/gpt/config/gpt.xml
+++ b/geoportal/src/gpt/config/gpt.xml
@@ -378,7 +378,8 @@
         <parameter key="httpClientRequest.connectionTimeout" value="2[MINUTE]"/>
         <parameter key="httpClientRequest.responseTimeout" value="2[MINUTE]"/>
         <parameter key="httpClient.alwaysClose" value="false"/>
-  
+        <!-- If set to true it allows the registration of web resources with same URL --> 
+ 	<parameter key="AllowDuplicateResourceURL" value="true"/>	  
         
 		    <!-- Resource Link Builder
 			      - resourceLinkBuilder.preview.filter: regular expression disabling ‘preview’ link on search result 


### PR DESCRIPTION
Added a parameter in gpt.xml:

```
 	<parameter key="AllowDuplicateResourceURL" value="true"/>
```
When set to true it allows to register web resources with same URL. This is useful to register the same resources with different profiles, that can be tailored to include filters. If the parameter is false or is not set than the default behaviour is follwed, i.e. URL must be unique.