### PR TITLE
Prevent iFrame Injection

### DIFF
--- a/javadoc/current/index.html
+++ b/javadoc/current/index.html
@@ -10,8 +10,49 @@ Esri Geoportal Server 1.2.9 API Specification
     targetPage = "" + window.location.search;
     if (targetPage != "" && targetPage != "undefined")
         targetPage = targetPage.substring(1);
-    if (targetPage.indexOf(":") != -1 || targetPage.indexOf("//") > -1 || targetPage.indexOf("com/") != 0)
+    if (targetPage.indexOf(":") != -1 || (targetPage != "" && !validURL(targetPage)))
         targetPage = "undefined";
+    function validURL(url) {
+        try {
+            url = decodeURIComponent(url);
+        }
+        catch (error) {
+            return false;
+        }
+        var pos = url.indexOf(".html");
+        if (pos == -1 || pos != url.length - 5)
+            return false;
+        var allowNumber = false;
+        var allowSep = false;
+        var seenDot = false;
+        for (var i = 0; i < url.length - 5; i++) {
+            var ch = url.charAt(i);
+            if ('a' <= ch && ch <= 'z' ||
+                    'A' <= ch && ch <= 'Z' ||
+                    ch == '$' ||
+                    ch == '_' ||
+                    ch.charCodeAt(0) > 127) {
+                allowNumber = true;
+                allowSep = true;
+            } else if ('0' <= ch && ch <= '9'
+                    || ch == '-') {
+                if (!allowNumber)
+                     return false;
+            } else if (ch == '/' || ch == '.') {
+                if (!allowSep)
+                    return false;
+                allowNumber = false;
+                allowSep = false;
+                if (ch == '.')
+                     seenDot = true;
+                if (ch == '/' && seenDot)
+                     return false;
+            } else {
+                return false;
+            }
+        }
+        return true;
+    }
     function loadFrames() {
         if (targetPage != "" && targetPage != "undefined")
              top.classFrame.location = top.targetPage;


### PR DESCRIPTION
This pull-request will prevent any/all forms of iFrame Injection within the Javadoc page.

> [!NOTE]
> While this is a security issue, due to the low-severity of it, I do not believe it needs to be kept confidential, and it can be publicly displayed as a Github Pull-Request.